### PR TITLE
fix: Correct archive write mode to prevent spam posting

### DIFF
--- a/src/promote_blog_post.py
+++ b/src/promote_blog_post.py
@@ -785,7 +785,7 @@ class PromoteBlogPost():
     def _save_rss_feed_archive(self, feed, rss_feed_archive):
         """ Save RSS feed archive to a file """
         archive_path = os.path.join(feed['ARCHIVE'][0], 'file.json')
-        with open(archive_path, 'wb') as fp:
+        with open(archive_path, 'w', encoding='utf-8') as fp:
             json.dump(rss_feed_archive, fp)
         self.logger.info("Archive for %s updated successfully.", feed['name'])
 
@@ -867,11 +867,17 @@ class PromoteBlogPost():
                     count_fails += 1
                     time.sleep(1)
 
-        if self.no_dry_run:
-            if result == 'success':
+        if self.no_dry_run and result == 'success':
+            try:
                 self._save_rss_feed_archive(
                     feed_config['feed'],
                     feed_config['rss_feed_archive']
+                )
+            except OSError as e:
+                self.logger.error(
+                    "Failed to save archive for %s: %s",
+                    feed_config['feed'].get('name', 'unknown'),
+                    e,
                 )
 
         return count_post


### PR DESCRIPTION
# What this PR is about

- Fix #8 🤞
  - Root cause: _save_rss_feed_archive opened the file in 'wb' (binary) mode — json.dump requires text mode in Python 3, so it raised TypeError on every save attempt
  - Cascade effect: the exception escaped _process_feed before return count_post, so process_feeds always saw count_post = 0, bypassing the 2-post limit and processing every feed
  - Fix 1: changed 'wb' → 'w', encoding='utf-8' so the archive is actually saved
  - Fix 2: wrapped the save call in its own try/except OSError so a future I/O failure logs an error but still returns count_post correctly, keeping the 2-post limit intact