### PR TITLE
fix: Bug in promote_blog_posts

### DIFF
--- a/src/promote_blog_post.py
+++ b/src/promote_blog_post.py
@@ -275,7 +275,8 @@ class PromoteBlogPost():
             "%a, %d %b %Y %H:%M:%S %z",  # Format 1
             "%a, %d %b %Y %H:%M:%S %Z",  # Format 2
             "%Y-%m-%d",                  # Format 3
-            "%Y-%m-%dT%H:%M:%S.%f%Z"     # Format 4
+            "%Y-%m-%dT%H:%M:%S.%f%Z",    # Format 4
+            "%Y-%m-%dT%H:%M:%S%z",       # Format 5: YouTube Atom (e.g. 2024-01-15T10:00:00+00:00)
         ]
 
         pub_date_str = entry.get('pub_date', '')
@@ -359,27 +360,34 @@ class PromoteBlogPost():
         return None
 
     def build_post_mastodon(
-        self, basis_text, platform_user_handle, tags, entry
+        self, title, name, platform_user_handle, tags, entry
     ):
         """
         Build Mastodon post.
         """
         platform_user_handle = self.check_platform_handle(platform_user_handle)
 
-        if platform_user_handle:
-            basis_text += f" ({platform_user_handle}) "
+        post = f'📝 "{title}"\n\n' if title else ''
+
         if self.config_dict.get('gen_ai_support', None):
             summarized_blog_post = self.summarize_text(entry)
             if summarized_blog_post:
-                basis_text += '\n\n📖 '
-                basis_text += summarized_blog_post
-        basis_text += f"\n\n🔗 {entry.get('link', '')}\n\n{tags}"
+                post += summarized_blog_post + '\n\n'
+
+        if name:
+            post += f'👤 {name}'
+        if platform_user_handle:
+            post += f' ({platform_user_handle})'
+        if name or platform_user_handle:
+            post += '\n\n'
+
+        post += f"🔗 {entry.get('link', '')}\n\n{tags}"
 
         self.logger.info('*****************************')
-        self.logger.info(basis_text)
+        self.logger.info(post)
         self.logger.info('*****************************')
 
-        return basis_text
+        return post
 
     @staticmethod
     def generate_text_to_summarize(entry):
@@ -438,7 +446,8 @@ class PromoteBlogPost():
 
     def build_post_bluesky(
         self,
-        basis_text,
+        title,
+        name,
         platform_user_handle,
         tags,
         entry
@@ -446,27 +455,58 @@ class PromoteBlogPost():
         """
         Build post for Bluesky.
         """
-        text_builder = client_utils.TextBuilder()
-        text_builder.text(basis_text)
-
+        bluesky_max_graphemes = 300
+        link = entry.get('link', '')
         platform_user_handle = self.check_platform_handle(platform_user_handle)
 
+        summarized_blog_post = ''
+        if self.config_dict.get('gen_ai_support', None):
+            summarized_blog_post = self.summarize_text(entry) or ''
+
+        # Calculate overhead of all parts except the title to enforce grapheme limit
+        overhead = 0
+        if summarized_blog_post:
+            overhead += len(summarized_blog_post) + 2  # +2 for '\n\n'
+        if name:
+            overhead += len('👤 ') + len(name)
+        if platform_user_handle:
+            overhead += len(f' ({platform_user_handle})')
+        if name or platform_user_handle:
+            overhead += 2  # '\n\n' after person block
+        overhead += len('🔗 ') + len(link) + 2  # +2 for '\n\n'
+        overhead += len(tags)
+
+        title_wrapper = len('📝 "') + len('"\n\n')  # 6 graphemes
+        available_for_title = bluesky_max_graphemes - overhead - title_wrapper
+        if title and len(title) > available_for_title:
+            title = title[:max(0, available_for_title - 1)] + '…'
+
+        text_builder = client_utils.TextBuilder()
+
+        if title:
+            text_builder.text(f'📝 "{title}"\n\n')
+
+        if summarized_blog_post:
+            text_builder.text(summarized_blog_post)
+            text_builder.text('\n\n')
+
+        if name:
+            text_builder.text(f'👤 {name}')
         if platform_user_handle:
             did = self.get_bluesky_did(platform_user_handle)
-            text_builder.mention(f" ({platform_user_handle})", did)
-        if self.config_dict.get('gen_ai_support', None):
-            summarized_blog_post = self.summarize_text(entry)
-            if summarized_blog_post:
-                text_builder.text('\n\n📖 ')
-                text_builder.text(summarized_blog_post)
-        text_builder.text('\n\n🔗 ')
-        link = entry.get('link', '')
+            text_builder.mention(f' ({platform_user_handle})', did)
+        if name or platform_user_handle:
+            text_builder.text('\n\n')
+
+        text_builder.text('🔗 ')
         text_builder.link(link, link)
         text_builder.text('\n\n')
+
         for tag in tags.split('#'):
             tag_clean = tag.strip()
             if tag_clean:
-                text_builder.tag(f"#{tag_clean} ", tag_clean)
+                text_builder.tag(f'#{tag_clean} ', tag_clean)
+
         return text_builder
 
     def build_post(self, entry, feed):
@@ -479,24 +519,18 @@ class PromoteBlogPost():
         title = entry.get('title', '')
         name = feed.get('name', '')
 
-        basis_text = ""
-
-        if title:
-            basis_text += f"📝 '{title}'\n\n"
-
-        if name:
-            basis_text += f"👤 {name}"
-
         if self.config_dict.get('platform', '') == 'mastodon':
             return self.build_post_mastodon(
-                basis_text,
+                title,
+                name,
                 platform_user_handle,
                 tags,
                 entry
             )
         if self.config_dict.get('platform', '') == 'bluesky':
             return self.build_post_bluesky(
-                basis_text,
+                title,
+                name,
                 platform_user_handle,
                 tags,
                 entry

--- a/tests/test_promote_blog_post.py
+++ b/tests/test_promote_blog_post.py
@@ -126,6 +126,11 @@ class TestParsePubDate:
         result = self.handler.parse_pub_date(entry)
         assert result == datetime(2024, 6, 15)
 
+    def test_youtube_atom_format(self):
+        entry = self._make_entry("2024-01-15T10:00:00+00:00")
+        result = self.handler.parse_pub_date(entry)
+        assert result == datetime(2024, 1, 15, 10, 0, 0)
+
     def test_fallback_to_today_on_unknown_format(self):
         entry = self._make_entry("not-a-valid-date")
         before = datetime.now()
@@ -354,18 +359,19 @@ class TestBuildPostMastodon:
         handler = make_handler({"platform": "mastodon", "gen_ai_support": False})
         entry = {"title": "T", "link": "https://x.com", "pub_date": "2024-01-01",
                  "tags": [], "summary": "", "media_content": []}
-        result = handler.build_post_mastodon("base text", "", "#tag", entry)
+        result = handler.build_post_mastodon("T", "Author", "", "#tag", entry)
         assert isinstance(result, str)
 
-    def test_gen_ai_summary_appended_with_concat(self):
-        # Verifies fix: basis_text += ... (not .text())
+    def test_gen_ai_summary_appended_without_emoji(self):
+        # Summary should appear in the post without the 📖 emoji prefix
         handler = make_handler({"platform": "mastodon", "gen_ai_support": True,
                                 "gemini_model_name": "gemini-2.5-flash"})
         entry = {"title": "T", "link": "https://x.com", "pub_date": "2024-01-01",
                  "tags": [], "summary": "content", "media_content": []}
         with patch.object(handler, "summarize_text", return_value="AI summary"):
-            result = handler.build_post_mastodon("base text", "", "#tag", entry)
+            result = handler.build_post_mastodon("T", "Author", "", "#tag", entry)
         assert "AI summary" in result
+        assert "📖" not in result
         assert isinstance(result, str)
 
     def test_no_gen_ai_no_summary(self):
@@ -373,15 +379,145 @@ class TestBuildPostMastodon:
         entry = {"title": "T", "link": "https://x.com", "pub_date": "2024-01-01",
                  "tags": [], "summary": "", "media_content": []}
         with patch.object(handler, "summarize_text") as mock_sum:
-            handler.build_post_mastodon("base", "", "#tag", entry)
+            handler.build_post_mastodon("T", "Author", "", "#tag", entry)
         mock_sum.assert_not_called()
 
     def test_platform_handle_included(self):
         handler = make_handler({"platform": "mastodon", "gen_ai_support": False})
         entry = {"title": "T", "link": "https://x.com", "pub_date": "2024-01-01",
                  "tags": [], "summary": "", "media_content": []}
-        result = handler.build_post_mastodon("base", "@author@example.social", "#tag", entry)
+        result = handler.build_post_mastodon("T", "Author", "@author@example.social", "#tag", entry)
         assert "@author@example.social" in result
+
+    def test_post_order(self):
+        # Verify: title → summary → name+handle → link → tags
+        handler = make_handler({"platform": "mastodon", "gen_ai_support": True,
+                                "gemini_model_name": "gemini-2.5-flash"})
+        entry = {"title": "My Title", "link": "https://x.com/post", "pub_date": "2024-01-01",
+                 "tags": [], "summary": "content", "media_content": []}
+        with patch.object(handler, "summarize_text", return_value="A short summary"):
+            result = handler.build_post_mastodon(
+                "My Title", "Jane Doe", "@jane", "#python ", entry
+            )
+        title_pos = result.index("My Title")
+        summary_pos = result.index("A short summary")
+        name_pos = result.index("Jane Doe")
+        link_pos = result.index("https://x.com/post")
+        tags_pos = result.index("#python")
+        assert title_pos < summary_pos < name_pos < link_pos < tags_pos
+
+    def test_title_uses_double_quotes(self):
+        handler = make_handler({"platform": "mastodon", "gen_ai_support": False})
+        entry = {"title": "My Title", "link": "https://x.com", "pub_date": "2024-01-01",
+                 "tags": [], "summary": "", "media_content": []}
+        result = handler.build_post_mastodon("My Title", "", "", "#tag", entry)
+        assert '📝 "My Title"' in result
+
+
+# ---------------------------------------------------------------------------
+# build_post_bluesky
+# ---------------------------------------------------------------------------
+
+class FakeTextBuilder:
+    """
+    Minimal TextBuilder stand-in that concatenates all text/link/tag/mention
+    display strings so tests can assert on the full rendered text.
+    """
+    def __init__(self):
+        self._parts = []
+
+    def text(self, s):
+        self._parts.append(s)
+        return self
+
+    def link(self, display, url):
+        self._parts.append(display)
+        return self
+
+    def mention(self, display, did):
+        self._parts.append(display)
+        return self
+
+    def tag(self, display, tag_name):
+        self._parts.append(display)
+        return self
+
+    def build_text(self):
+        return "".join(self._parts)
+
+
+class TestBuildPostBluesky:
+    BASE_ENTRY = {
+        "title": "My Post Title",
+        "link": "https://example.com/post",
+        "pub_date": "2024-01-01",
+        "tags": [],
+        "summary": "",
+        "media_content": [],
+    }
+
+    def _make_handler_with_fake_builder(self, config=None):
+        """Return a handler whose client_utils.TextBuilder produces FakeTextBuilder."""
+        handler = make_handler(config or {"platform": "bluesky", "gen_ai_support": False})
+        import promote_blog_post as pbp
+        pbp.client_utils.TextBuilder.side_effect = FakeTextBuilder
+        return handler
+
+    def test_title_uses_double_quotes(self):
+        handler = self._make_handler_with_fake_builder()
+        with patch.object(handler, "get_bluesky_did", return_value="did:plc:test"):
+            builder = handler.build_post_bluesky(
+                "My Title", "Author", "", "#python ", self.BASE_ENTRY
+            )
+        assert '📝 "My Title"' in builder.build_text()
+
+    def test_post_order(self):
+        # Verify: title → summary → name+handle → link → tags
+        handler = self._make_handler_with_fake_builder(
+            {"platform": "bluesky", "gen_ai_support": True, "gemini_model_name": "gemini-2.5-flash"}
+        )
+        entry = {**self.BASE_ENTRY, "link": "https://example.com/post"}
+        with patch.object(handler, "summarize_text", return_value="Short summary"), \
+             patch.object(handler, "get_bluesky_did", return_value="did:plc:test"):
+            builder = handler.build_post_bluesky(
+                "My Title", "Jane Doe", "@jane", "#python ", entry
+            )
+        text = builder.build_text()
+        assert text.index("My Title") < text.index("Short summary")
+        assert text.index("Short summary") < text.index("Jane Doe")
+        assert text.index("Jane Doe") < text.index("https://example.com/post")
+        assert text.index("https://example.com/post") < text.index("#python")
+
+    def test_no_summary_emoji(self):
+        handler = self._make_handler_with_fake_builder(
+            {"platform": "bluesky", "gen_ai_support": True, "gemini_model_name": "gemini-2.5-flash"}
+        )
+        with patch.object(handler, "summarize_text", return_value="AI summary"), \
+             patch.object(handler, "get_bluesky_did", return_value="did:plc:test"):
+            builder = handler.build_post_bluesky(
+                "T", "Author", "", "#python ", self.BASE_ENTRY
+            )
+        assert "📖" not in builder.build_text()
+
+    def test_long_title_truncated_to_fit_300_graphemes(self):
+        handler = self._make_handler_with_fake_builder()
+        long_title = "A" * 280  # will exceed 300 once link + tags are added
+        entry = {**self.BASE_ENTRY, "link": "https://example.com/post"}
+        with patch.object(handler, "get_bluesky_did", return_value="did:plc:test"):
+            builder = handler.build_post_bluesky(
+                long_title, "Author", "", "#python ", entry
+            )
+        assert len(builder.build_text()) <= 300
+
+    def test_short_title_not_truncated(self):
+        handler = self._make_handler_with_fake_builder()
+        with patch.object(handler, "get_bluesky_did", return_value="did:plc:test"):
+            builder = handler.build_post_bluesky(
+                "Short title", "Author", "", "#python ", self.BASE_ENTRY
+            )
+        text = builder.build_text()
+        assert "Short title" in text
+        assert "…" not in text
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# What this PR is about

- Add YouTube Atom date format (%Y-%m-%dT%H:%M:%S%z) to parse_pub_date 
- Enforce Bluesky 300 grapheme limit by truncating title when post is too long 
- Unify post order for both Bluesky and Mastodon: title → summary → author+handle → link → tags 
- Remove 📖 emoji from AI summary; pass title/name separately to builders
- Fix and update unit tests
