### PR TITLE
fix: Circular author rotation and tag-trimming for Bluesky 300-graphe…

### DIFF
--- a/src/promote_blog_post.py
+++ b/src/promote_blog_post.py
@@ -127,43 +127,42 @@ class PromoteBlogPost():
         """
         Method to handle processing of all feeds.
         """
-        for feed in feeds:
-            if counter_name not in (feed['name'], '\n', ''):
-                continue
+        n = len(feeds)
+        if n == 0:
+            return
+
+        start_index = 0
+        for i, f in enumerate(feeds):
+            if counter_name in (f['name'], '\n', ''):
+                start_index = i
+                break
+
+        next_index = start_index
+
+        for offset in range(n):
+            idx = (start_index + offset) % n
+            feed = feeds[idx]
+
             if len(feed['rss_feed']) == 0 or feed['rss_feed'] == [None]:
                 continue
 
-            is_last_feed = feed['name'] == feeds[-1]['name']
-
-            if count_post == 0 and is_last_feed:
-                count_post = self.process_feed(feed, count_post, client)
-                new_feed = feeds[0]
-                count_post = self.process_feed(new_feed, count_post, client)
+            if count_post >= 2:
+                next_index = idx
                 self.logger.info(
                     "Successfully promoted blog posts. "
                     "Thank you and see you next time!")
-                next_counter = feeds[1]['name'] if len(feeds) > 1 else feeds[0]['name']
-                self.update_counter(next_counter)
                 break
 
-            elif count_post < 2:
-                count_post = self.process_feed(
-                    feed,
-                    count_post,
-                    client
-                )
-                counter_name = ''
-                if is_last_feed:
-                    self.update_counter(feed['name'])
-                self.logger.info(
-                    "=========================================")
-
-            else:
+            count_post = self.process_feed(feed, count_post, client)
+            next_index = (idx + 1) % n
+            self.logger.info("=========================================")
+        else:
+            if count_post >= 2:
                 self.logger.info(
                     "Successfully promoted blog posts. "
                     "Thank you and see you next time!")
-                self.update_counter(feed['name'])
-                break
+
+        self.update_counter(feeds[next_index]['name'])
 
     def update_counter(self, counter_name):
         """
@@ -466,10 +465,12 @@ class PromoteBlogPost():
         # Resolve DID once so _build() never makes a duplicate HTTP call
         did = self.get_bluesky_did(platform_user_handle) if platform_user_handle else None
 
-        def _build(t):
+        tag_list = [t.strip() for t in tags.split('#') if t.strip()]
+
+        def _build(tag_subset):
             tb = client_utils.TextBuilder()
-            if t:
-                tb.text(f'📝 "{t}"\n\n')
+            if title:
+                tb.text(f'📝 "{title}"\n\n')
             if summarized_blog_post:
                 tb.text(summarized_blog_post)
                 tb.text('\n\n')
@@ -482,22 +483,17 @@ class PromoteBlogPost():
             tb.text('🔗 ')
             tb.link(link, link)
             tb.text('\n\n')
-            for tag in tags.split('#'):
-                tag_clean = tag.strip()
-                if tag_clean:
-                    tb.tag(f'#{tag_clean} ', tag_clean)
+            for tag_clean in tag_subset:
+                tb.tag(f'#{tag_clean} ', tag_clean)
             return tb
 
-        text_builder = _build(title)
+        # Try with all tags; drop from the end one by one until within limit
+        for count in range(len(tag_list), -1, -1):
+            text_builder = _build(tag_list[:count])
+            if len(text_builder.build_text()) <= bluesky_max_graphemes:
+                return text_builder
 
-        # Measure actual grapheme count; trim title by the exact excess if needed
-        actual_len = len(text_builder.build_text())
-        if actual_len > bluesky_max_graphemes:
-            excess = actual_len - bluesky_max_graphemes
-            trimmed_title = title[:max(0, len(title) - excess - 1)] + '…'
-            text_builder = _build(trimmed_title)
-
-        return text_builder
+        return _build([])
 
     def build_post(self, entry, feed):
         """Take the entry dict and build a post"""

--- a/tests/test_promote_blog_post.py
+++ b/tests/test_promote_blog_post.py
@@ -499,17 +499,31 @@ class TestBuildPostBluesky:
             )
         assert "📖" not in builder.build_text()
 
-    def test_long_title_truncated_to_fit_300_graphemes(self):
+    def test_tags_trimmed_to_fit_300_graphemes(self):
         handler = self._make_handler_with_fake_builder()
-        long_title = "A" * 280  # will exceed 300 once link + tags are added
+        # 30 tags of ~10 chars each — far exceeds 300 with the rest of the post
+        many_tags = " ".join(f"#longtag{i:02d}" for i in range(30))
         entry = {**self.BASE_ENTRY, "link": "https://example.com/post"}
         with patch.object(handler, "get_bluesky_did", return_value="did:plc:test"):
             builder = handler.build_post_bluesky(
-                long_title, "Author", "", "#python ", entry
+                "My Post Title", "Author", "", many_tags, entry
             )
-        assert len(builder.build_text()) <= 300
+        text = builder.build_text()
+        assert len(text) <= 300
+        assert "My Post Title" in text  # title is preserved
+        assert "…" not in text          # title not truncated with ellipsis
 
-    def test_short_title_not_truncated(self):
+    def test_title_preserved_when_tags_trimmed(self):
+        handler = self._make_handler_with_fake_builder()
+        many_tags = " ".join(f"#tag{i}" for i in range(50))
+        entry = {**self.BASE_ENTRY, "link": "https://example.com/post"}
+        with patch.object(handler, "get_bluesky_did", return_value="did:plc:test"):
+            builder = handler.build_post_bluesky(
+                "Important Title", "Author", "", many_tags, entry
+            )
+        assert "Important Title" in builder.build_text()
+
+    def test_all_tags_kept_when_post_fits(self):
         handler = self._make_handler_with_fake_builder()
         with patch.object(handler, "get_bluesky_did", return_value="did:plc:test"):
             builder = handler.build_post_bluesky(
@@ -517,6 +531,7 @@ class TestBuildPostBluesky:
             )
         text = builder.build_text()
         assert "Short title" in text
+        assert "#python" in text
         assert "…" not in text
 
 
@@ -771,7 +786,7 @@ class TestProcessFeeds:
         feeds = self._make_feeds(["Alice", "Bob", "Carol"])
 
         def fake_process(feed, count_post, client):
-            return count_post  # nothing posted → stays 0
+            return count_post + 1  # one post per feed
 
         captured_counter = []
 
@@ -780,7 +795,7 @@ class TestProcessFeeds:
                  handler, "update_counter",
                  side_effect=captured_counter.append
              ):
-            # counter_name matches last feed → wrap-around path
+            # counter_name matches last feed → should process Carol, Alice, then stop at Bob
             handler.process_feeds(feeds, "Carol", 0, MagicMock())
 
         assert "Bob" in captured_counter  # wraps to feeds[1]


### PR DESCRIPTION
# What this PR is about

**process_feeds — circular loop (src/promote_blog_post.py):**

- Removed the is_last_feed special case entirely
- Uses (start_index + offset) % n to iterate circularly from the counter's position
- next_index tracks where to start next run: advances to (idx + 1) % n after each feed, or stays at idx when the 2-post cap is hit (so we don't skip that feed next run)
- update_counter called once at the end — no more duplicate / scattered calls

**build_post_bluesky — tag trimming (src/promote_blog_post.py):**

- _build now takes tag_subset (a list) instead of a title variant
- Loops range(len(tag_list), -1, -1): tries all tags, then drops one from the end at a time until the post fits within 300 graphemes
- Title is never modified