### PR TITLE
Improve boost tags

### DIFF
--- a/.github/workflows/pyladies_boost_tags.yml
+++ b/.github/workflows/pyladies_boost_tags.yml
@@ -2,7 +2,12 @@ name: Boost posts that the tag pyladies
 
 on:
     schedule:
-    - cron: '5 */6 * * *' #'0 */12 * * *' 
+    - cron: '5 */6 * * *' #'0 */12 * * *'
+    workflow_dispatch:
+        inputs:
+            tags:
+                description: 'Comma-separated tags to boost'
+                default: 'pyladies'
 
 jobs:
     build:
@@ -40,5 +45,5 @@ jobs:
             CLIENT_NAME: "pyladies_bot"
             PASSWORD: ${{ secrets.PYLADIES_BSKY_PASSWORD }}
             USERNAME: ${{ secrets.PYLADIES_BSKY_USERNAME }}
-            TAGS_TO_BOOST: "pyladies"
+            TAGS_TO_BOOST: ${{ github.event.inputs.tags || 'pyladies' }}
           run: python src/boost_tags.py

--- a/.github/workflows/rladies_boost_tags.yml
+++ b/.github/workflows/rladies_boost_tags.yml
@@ -2,7 +2,12 @@ name: Boost posts that the tag rladies
 
 on:
     schedule:
-    - cron: '0 */6 * * *' #'5 */12 * * *'  
+    - cron: '0 */6 * * *' #'5 */12 * * *'
+    workflow_dispatch:
+        inputs:
+            tags:
+                description: 'Comma-separated tags to boost'
+                default: 'rladies'
 
 jobs:
     build:
@@ -40,5 +45,5 @@ jobs:
               CLIENT_NAME: "rladies_bot"
               PASSWORD: ${{ secrets.RLADIES_BSKY_PASSWORD }}
               USERNAME: ${{ secrets.RLADIES_BSKY_USERNAME }}
-              TAGS_TO_BOOST: "rladies"
+              TAGS_TO_BOOST: ${{ github.event.inputs.tags || 'rladies' }}
           run: python src/boost_tags.py

--- a/src/boost_mentions.py
+++ b/src/boost_mentions.py
@@ -179,7 +179,10 @@ class BoostMentions:
         """
         if self.config_dict is None:
             self.config_dict = {}
-        self.config_dict.setdefault("platform", os.getenv("PLATFORM"))
+        platform = (os.getenv("PLATFORM") or "").lower()
+        if not platform and not self.config_dict.get("platform"):
+            raise ValueError("PLATFORM environment variable is not set.")
+        self.config_dict.setdefault("platform", platform)
         self.config_dict.setdefault("password", os.getenv("PASSWORD"))
         self.config_dict.setdefault("username", os.getenv("USERNAME"))
         self.config_dict.setdefault("client_name", os.getenv("CLIENT_NAME"))
@@ -193,7 +196,7 @@ class BoostMentions:
             )
             self.config_dict.setdefault("timeline_depth_limit", 40)
         elif self.config_dict["platform"] == "bluesky":
-            self.config_dict.setdefault("api_base_url", "bluesky")
+            self.config_dict.setdefault("api_base_url", "https://bsky.social")
         else:
             raise ValueError(
                 f"Unknown platform: {self.config_dict['platform']!r}. "

--- a/src/boost_tags.py
+++ b/src/boost_tags.py
@@ -148,6 +148,7 @@ class BoostTags:
 
         for tag in self.cfg["tags"]:
             tag = tag.lower().strip("# ")
+            self.logger.info(" > Searching for tag #%s", tag)
             if boost_count >= max_boosts:
                 self.logger.info(
                     " > Reached max boosts per run (%d), stopping.", max_boosts

--- a/src/boost_tags.py
+++ b/src/boost_tags.py
@@ -20,9 +20,13 @@ except ImportError:  # pragma: no cover - optional dependency
 
 try:
     from atproto.exceptions import AtProtocolError  # type: ignore
+    from atproto_client.exceptions import InvokeTimeoutError  # type: ignore
 except ImportError:  # pragma: no cover - optional dependency
     class AtProtocolError(Exception):
         """Fallback Bluesky/AtProto error."""
+
+    class InvokeTimeoutError(Exception):
+        """Fallback Bluesky timeout error."""
 
 
 load_dotenv()
@@ -124,11 +128,19 @@ class BoostTags:
 
     def _boost_tags_bluesky(self) -> None:
         """Handle reposting tags on Bluesky."""
-        client = login_bluesky(cast(BlueskyConfig, self.config_dict))
+        try:
+            client = login_bluesky(cast(BlueskyConfig, self.config_dict))
+        except InvokeTimeoutError:
+            self.logger.error("Timed out while logging in to Bluesky. Aborting.")
+            return
         self.logger.info(" > Fetched Bluesky account data.")
         self.logger.info(" > Starting search-loop for reposting.")
 
-        timeline = client.get_timeline(algorithm="reverse-chronological")
+        try:
+            timeline = client.get_timeline(algorithm="reverse-chronological")
+        except InvokeTimeoutError:
+            self.logger.error("Timed out fetching timeline. Aborting.")
+            return
         seen_cids = {post.post.cid for post in timeline.feed}
 
         max_boosts = self.cfg.get("max_boosts_per_run", 5)
@@ -142,9 +154,13 @@ class BoostTags:
                 )
                 break
 
-            response = client.app.bsky.feed.search_posts(
-                params={"q": tag, "tag": [tag], "sort": "top", "limit": 50}
-            )
+            try:
+                response = client.app.bsky.feed.search_posts(
+                    params={"q": tag, "tag": [tag], "sort": "top", "limit": 50}
+                )
+            except InvokeTimeoutError:
+                self.logger.error("Timed out searching posts for tag #%s. Skipping.", tag)
+                continue
             for post in response.posts:
                 if boost_count >= max_boosts:
                     break

--- a/src/boost_tags.py
+++ b/src/boost_tags.py
@@ -3,13 +3,12 @@
 import time
 import os
 import logging
-from urllib.parse import urlparse
+from typing import Optional, Dict, Any, cast
 from dotenv import load_dotenv
 
 import config
-from helper.login_bluesky import login_bluesky
+from helper.login_bluesky import login_bluesky, BlueskyConfig
 
-# Try to import platform-specific exceptions; provide safe fallbacks if unavailable.
 try:
     from mastodon import MastodonNetworkError, MastodonAPIError  # type: ignore
 except ImportError:  # pragma: no cover - optional dependency
@@ -35,76 +34,32 @@ class BoostTags:
     Currently supports Bluesky. Mastodon support is stubbed.
     """
 
-    def __init__(self, config_dict: dict | None = None, no_dry_run: bool = True) -> None:
+    def __init__(
+        self,
+        config_dict: Optional[Dict[str, Any]] = None,
+        no_dry_run: bool = True,
+    ) -> None:
         """
         Initialize the BoostTags handler.
 
         Args:
-            config_dict (dict | None): Configuration dictionary for the bot.
-                If None, values will be loaded from environment variables.
-            no_dry_run (bool): If True, actually perform reposts instead of dry-run.
+            config_dict: Optional configuration dictionary for the bot.
+            no_dry_run: If True, actually perform reposts; if False, dry run.
         """
         self.logger = logging.getLogger(__name__)
-        self.logger.setLevel(logging.INFO)
 
-        self.config_dict = config_dict
         self.no_dry_run = no_dry_run
+        self.config_dict = config_dict
 
-    def repost_tags_mastodon(self, client) -> None:
-        """
-        Repost Mastodon statuses containing the configured tags.
-
-        Args:
-            client: Authenticated Mastodon client instance.
-
-        Notes:
-            Currently non-functional since account fetching is commented out.
-        """
-        if "tags" not in self.config_dict:
-            self.logger.warning("No tags configured for Mastodon reposts.")
-            return
-
-        for tag in self.config_dict["tags"]:
-            tag = tag.lower().strip("# ")
-            self.logger.info("Reading timeline for new toots tagged #%s", tag)
-
-            try:
-                statuses = client.timeline_hashtag(
-                    tag,
-                    limit=self.config_dict.get("timeline_depth_limit", 40),
-                )
-            except (
-                MastodonNetworkError,
-                MastodonAPIError,
-                ConnectionError,
-                TimeoutError
-            ) as e:
-                # NOTE: Replace/extend with library-specific 
-                # exceptions as needed.
-                self.logger.error(
-                    "Network/API error when fetching statuses: %s. Retrying...",
-                    e
-                )
-                time.sleep(30)
-                continue
-
-            time.sleep(0.1)  # rate limiting
-
-            for status in statuses:
-                domain = urlparse(status.url).netloc
-                if (
-                    not getattr(status, "favourited", False)
-                    and domain not in config.IGNORE_SERVERS
-                    and getattr(status.account, "acct", None) != self.config_dict.get("username")
-                ):
-                    self.logger.info(
-                        "Boosting toot by %s tagged #%s (%s)",
-                        status.account.username,
-                        tag,
-                        status.url,
-                    )
-                    client.status_reblog(status.id)
-                    client.status_favourite(status.id)
+    @property
+    def cfg(self) -> Dict[str, Any]:
+        """Property to ensure that the dictionary is initialized."""
+        if self.config_dict is None:
+            raise RuntimeError(
+                "config_dict is not set; call boost_tags() or pass "
+                "config_dict to the constructor before accessing cfg"
+            )
+        return self.config_dict
 
     def boost_tags(self) -> None:
         """
@@ -113,102 +68,133 @@ class BoostTags:
         Loads configuration from environment variables if not provided.
         Handles platform-specific reposting logic.
         """
-        if self.config_dict is None and self.no_dry_run:
-            self._load_config_from_env()
+        self.set_up_config_dict()
 
-        platform = self.config_dict.get("platform")
-        client_name = self.config_dict.get("client_name", "Unknown")
+        client_name = self.cfg.get("client_name", "Unknown")
         self.logger.info("========")
         self.logger.info("Initializing %s Bot", client_name)
         self.logger.info("=" * (20 + len(client_name)))
-        self.logger.info("Connecting to %s", self.config_dict["api_base_url"])
+        self.logger.info(" > Connecting to %s", self.cfg["api_base_url"])
 
-        if platform == "mastodon":
+        if self.cfg["platform"] == "mastodon":
             self._boost_tags_mastodon()
-            self.logger.warning("Mastodon support is currently not implemented.")
-        elif platform == "bluesky":
+        elif self.cfg["platform"] == "bluesky":
             self._boost_tags_bluesky()
-        else:
-            self.logger.error("Unsupported platform: %s", platform)
 
-    def _load_config_from_env(self) -> None:
-        """Load configuration values from environment variables into self.config_dict."""
-        self.config_dict = {
-            "platform": os.getenv("PLATFORM", "").lower(),
-            "password": os.getenv("PASSWORD"),
-            "username": os.getenv("USERNAME"),
-            "client_name": os.getenv("CLIENT_NAME", "CommunityBot"),
-            "tags": os.getenv("TAGS_TO_BOOST", "").split(","),
-        }
+    def set_up_config_dict(self) -> None:
+        """
+        Populate the configuration dictionary with required parameters.
+
+        Loads environment variables and values from `config` to prepare
+        platform-specific settings.
+        """
+        if self.config_dict is None:
+            self.config_dict = {}
+        platform = (os.getenv("PLATFORM") or "").lower()
+        if not platform and not self.config_dict.get("platform"):
+            raise ValueError("PLATFORM environment variable is not set.")
+        self.config_dict.setdefault("platform", platform)
+        self.config_dict.setdefault("password", os.getenv("PASSWORD"))
+        self.config_dict.setdefault("username", os.getenv("USERNAME"))
+        self.config_dict.setdefault("client_name", os.getenv("CLIENT_NAME", "CommunityBot"))
+        self.config_dict.setdefault(
+            "tags",
+            [t.strip() for t in os.getenv("TAGS_TO_BOOST", "").split(",") if t.strip()],
+        )
+        self.config_dict.setdefault("max_boosts_per_run", 5)
         if self.config_dict["platform"] == "mastodon":
-            self.config_dict.update({
-                "mastodon_visibility": config.MASTODON_VISIBILITY,
-                "api_base_url": config.API_BASE_URL,
-                "access_token": os.getenv("ACCESS_TOKEN"),
-                "client_cred_file": os.getenv("BOT_CLIENTCRED_SECRET"),
-                "timeline_depth_limit": 40,
-            })
+            self.config_dict.setdefault("mastodon_visibility", config.MASTODON_VISIBILITY)
+            self.config_dict.setdefault("api_base_url", config.API_BASE_URL)
+            self.config_dict.setdefault("access_token", os.getenv("ACCESS_TOKEN"))
+            self.config_dict.setdefault(
+                "client_cred_file", os.getenv("BOT_CLIENTCRED_SECRET")
+            )
+            self.config_dict.setdefault("timeline_depth_limit", 40)
+        elif self.config_dict["platform"] == "bluesky":
+            self.config_dict.setdefault("api_base_url", "https://bsky.social")
         else:
-            self.config_dict["api_base_url"] = "bluesky"
+            raise ValueError(
+                f"Unknown platform: {self.config_dict['platform']!r}. "
+                "Expected 'mastodon' or 'bluesky'."
+            )
 
     def _boost_tags_mastodon(self) -> None:
         """Handle reposting tags on Mastodon."""
-        # # Commented because it wasn't fully working
-
-        # account, client = login_mastodon(config_dict)
-        # self.logger.info(f" > Fetched account data for {account.acct}")
-
-        # repost_tags_mastodon(client, config_dict)
-        self.logger.info(
-            """
-            This feature currently doesn't work for Mastodon.
-            It's deployed using AWS.
-            """
-        )
+        raise NotImplementedError("Mastodon tag boosting is not yet implemented.")
 
     def _boost_tags_bluesky(self) -> None:
         """Handle reposting tags on Bluesky."""
-        if not self.no_dry_run:
-            self.logger.info("Dry-run mode: no reposts will be made.")
-            return
-
-        client = login_bluesky(self.config_dict)
-        self.logger.info("Fetched Bluesky account data.")
-        self.logger.info("Starting search-loop for reposting.")
+        client = login_bluesky(cast(BlueskyConfig, self.config_dict))
+        self.logger.info(" > Fetched Bluesky account data.")
+        self.logger.info(" > Starting search-loop for reposting.")
 
         timeline = client.get_timeline(algorithm="reverse-chronological")
         seen_cids = {post.post.cid for post in timeline.feed}
 
-        for tag in self.config_dict["tags"]:
+        max_boosts = self.cfg.get("max_boosts_per_run", 5)
+        boost_count = 0
+
+        for tag in self.cfg["tags"]:
+            tag = tag.lower().strip("# ")
+            if boost_count >= max_boosts:
+                self.logger.info(
+                    " > Reached max boosts per run (%d), stopping.", max_boosts
+                )
+                break
+
             response = client.app.bsky.feed.search_posts(
                 params={"q": tag, "tag": [tag], "sort": "top", "limit": 50}
             )
             for post in response.posts:
-                tags_in_post = {
-                    t.strip("#").lower()
-                    for t in post.record.text.split()
-                    if t.startswith("#")
-                }
+                if boost_count >= max_boosts:
+                    break
 
-                if tag.lower() in tags_in_post and post.cid not in seen_cids:
-                    try:
-                        result = client.repost(uri=post.uri, cid=post.cid)
+                # Prefer facets (structured ATProto tags) over text parsing.
+                tags_in_post: set = set()
+                for facet in (getattr(post.record, "facets", None) or []):
+                    for feature in facet.features:
+                        if hasattr(feature, "tag"):
+                            tags_in_post.add(feature.tag.lower())
+                if not tags_in_post:
+                    tags_in_post = {
+                        t.strip("#.,!?").lower()
+                        for t in post.record.text.split()
+                        if t.startswith("#")
+                    }
+
+                if tag in tags_in_post and post.cid not in seen_cids:
+                    if not self.no_dry_run:
                         self.logger.info(
-                            "Reposted post by %s (ref: %s)",
-                            post.author.handle, result
-                        )
-                    except AtProtocolError as e:
-                        self.logger.error(
-                            "Failed to repost URI %s, CID %s: %s",
+                            "   * [DRY RUN] Would repost URI %s CID %s by %s",
                             post.uri,
                             post.cid,
-                            e,
+                            post.author.handle,
                         )
+                        seen_cids.add(post.cid)
+                        boost_count += 1
+                    else:
+                        try:
+                            result = client.repost(uri=post.uri, cid=post.cid)
+                            self.logger.info(
+                                "   * Reposted post by %s (ref: %s)",
+                                post.author.handle,
+                                result,
+                            )
+                            seen_cids.add(post.cid)
+                            boost_count += 1
+                        except AtProtocolError as e:
+                            self.logger.error(
+                                "   * Failed to repost URI %s, CID %s: %s",
+                                post.uri,
+                                post.cid,
+                                e,
+                            )
                     time.sleep(0.1)  # avoid hammering API
 
         self.logger.info("Finished processing Bluesky reposts.")
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
     bot = BoostTags()
     bot.boost_tags()

--- a/src/boost_tags.py
+++ b/src/boost_tags.py
@@ -179,7 +179,12 @@ class BoostTags:
                         if t.startswith("#")
                     }
 
-                if tag in tags_in_post and post.cid not in seen_cids:
+                own_handle = (self.cfg.get("username") or "").lower()
+                if (
+                    tag in tags_in_post
+                    and post.cid not in seen_cids
+                    and post.author.handle.lower() != own_handle
+                ):
                     if not self.no_dry_run:
                         self.logger.info(
                             "   * [DRY RUN] Would repost URI %s CID %s by %s",

--- a/src/debug.py
+++ b/src/debug.py
@@ -20,7 +20,7 @@ class DebugBots:
     """
     def __init__(self):
         self.bot = 'pyladies'  # 'pyladies' or 'rladies'
-        self.what_to_debug = 'blog'  # 'blog', 'boost_tags', 'rss', 'anniversary', 'boost_mentions'
+        self.what_to_debug = 'boost_tags'  # 'blog', 'boost_tags', 'rss', 'anniversary', 'boost_mentions'
         self.platform = 'bluesky'  # 'bluesky' or 'mastodon'
         self.no_dry_run = False  # True to actually post
 
@@ -174,12 +174,11 @@ class DebugBots:
             if self.platform == 'bluesky':
                 return {
                     "client_name": "pyladies_bot",
-                    "api_base_url": self.platform,
                     "mastodon": None,
                     "password": os.getenv("PYLADIES_BSKY_PASSWORD"),
                     "username": os.getenv("PYLADIES_BSKY_USERNAME"),
                     "platform": self.platform,
-                    "tags": "pyladies",
+                    "tags": ["pyladies"],
                 }
             if self.platform == 'mastodon':
                 return {
@@ -192,19 +191,18 @@ class DebugBots:
                     "client_cred_file": os.getenv("PYLADIES_BOT_CLIENTCRED_SECRET"),
                     "platform": self.platform,
                     "mastodon_visibility": config.MASTODON_VISIBILITY,
-                    "tags": "pyladies",
+                    "tags": ["pyladies"],
                 }
 
         if self.bot == 'rladies':
             if self.platform == "bluesky":
                 return {
                     "client_name": "rladies_bot",
-                    "api_base_url": self.platform,
                     "mastodon": None,
                     "password": os.getenv("RLADIES_BSKY_PASSWORD"),
                     "username": os.getenv("RLADIES_BSKY_USERNAME"),
                     "platform": self.platform,
-                    "tags": "rladies",
+                    "tags": ["rladies"],
                 }
             if self.platform == 'mastodon':
                 return {
@@ -217,7 +215,7 @@ class DebugBots:
                     "client_cred_file": os.getenv("RLADIES_BOT_CLIENTCRED_SECRET"),
                     "platform": self.platform,
                     "mastodon_visibility": config.MASTODON_VISIBILITY,
-                    "tags": "rladies",
+                    "tags": ["rladies"],
                 }
 
         return None

--- a/src/debug.py
+++ b/src/debug.py
@@ -20,7 +20,7 @@ class DebugBots:
     """
     def __init__(self):
         self.bot = 'pyladies'  # 'pyladies' or 'rladies'
-        self.what_to_debug = 'blog'  # 'blog', 'boost_tags', 'rss', 'anniversary', 'boost_mentions'
+        self.what_to_debug = 'boost_tags'  # 'blog', 'boost_tags', 'rss', 'anniversary', 'boost_mentions'
         self.platform = 'bluesky'  # 'bluesky' or 'mastodon'
         self.no_dry_run = False  # True to actually post
 
@@ -179,7 +179,7 @@ class DebugBots:
                     "password": os.getenv("PYLADIES_BSKY_PASSWORD"),
                     "username": os.getenv("PYLADIES_BSKY_USERNAME"),
                     "platform": self.platform,
-                    "tags": "pyladies",
+                    "tags": ["pyladies"],
                 }
             if self.platform == 'mastodon':
                 return {
@@ -192,7 +192,7 @@ class DebugBots:
                     "client_cred_file": os.getenv("PYLADIES_BOT_CLIENTCRED_SECRET"),
                     "platform": self.platform,
                     "mastodon_visibility": config.MASTODON_VISIBILITY,
-                    "tags": "pyladies",
+                    "tags": ["pyladies"],
                 }
 
         if self.bot == 'rladies':
@@ -204,7 +204,7 @@ class DebugBots:
                     "password": os.getenv("RLADIES_BSKY_PASSWORD"),
                     "username": os.getenv("RLADIES_BSKY_USERNAME"),
                     "platform": self.platform,
-                    "tags": "rladies",
+                    "tags": ["rladies"],
                 }
             if self.platform == 'mastodon':
                 return {
@@ -217,7 +217,7 @@ class DebugBots:
                     "client_cred_file": os.getenv("RLADIES_BOT_CLIENTCRED_SECRET"),
                     "platform": self.platform,
                     "mastodon_visibility": config.MASTODON_VISIBILITY,
-                    "tags": "rladies",
+                    "tags": ["rladies"],
                 }
 
         return None

--- a/src/debug.py
+++ b/src/debug.py
@@ -20,7 +20,7 @@ class DebugBots:
     """
     def __init__(self):
         self.bot = 'pyladies'  # 'pyladies' or 'rladies'
-        self.what_to_debug = 'boost_tags'  # 'blog', 'boost_tags', 'rss', 'anniversary', 'boost_mentions'
+        self.what_to_debug = 'blog'  # 'blog', 'boost_tags', 'rss', 'anniversary', 'boost_mentions'
         self.platform = 'bluesky'  # 'bluesky' or 'mastodon'
         self.no_dry_run = False  # True to actually post
 
@@ -179,7 +179,7 @@ class DebugBots:
                     "password": os.getenv("PYLADIES_BSKY_PASSWORD"),
                     "username": os.getenv("PYLADIES_BSKY_USERNAME"),
                     "platform": self.platform,
-                    "tags": ["pyladies"],
+                    "tags": "pyladies",
                 }
             if self.platform == 'mastodon':
                 return {
@@ -192,7 +192,7 @@ class DebugBots:
                     "client_cred_file": os.getenv("PYLADIES_BOT_CLIENTCRED_SECRET"),
                     "platform": self.platform,
                     "mastodon_visibility": config.MASTODON_VISIBILITY,
-                    "tags": ["pyladies"],
+                    "tags": "pyladies",
                 }
 
         if self.bot == 'rladies':
@@ -204,7 +204,7 @@ class DebugBots:
                     "password": os.getenv("RLADIES_BSKY_PASSWORD"),
                     "username": os.getenv("RLADIES_BSKY_USERNAME"),
                     "platform": self.platform,
-                    "tags": ["rladies"],
+                    "tags": "rladies",
                 }
             if self.platform == 'mastodon':
                 return {
@@ -217,7 +217,7 @@ class DebugBots:
                     "client_cred_file": os.getenv("RLADIES_BOT_CLIENTCRED_SECRET"),
                     "platform": self.platform,
                     "mastodon_visibility": config.MASTODON_VISIBILITY,
-                    "tags": ["rladies"],
+                    "tags": "rladies",
                 }
 
         return None

--- a/tests/test_boost_mentions.py
+++ b/tests/test_boost_mentions.py
@@ -139,7 +139,7 @@ class TestSetUpConfigDict:
         with patch.dict(os.environ, env, clear=True):
             handler.set_up_config_dict()
 
-        assert handler.config_dict["api_base_url"] == "bluesky"
+        assert handler.config_dict["api_base_url"] == "https://bsky.social"
 
     def test_unknown_platform_raises_value_error(self):
         # A misconfigured / missing PLATFORM must fail loudly, not silently
@@ -154,7 +154,7 @@ class TestSetUpConfigDict:
         # Missing PLATFORM env var must also raise, not default to Bluesky
         handler = BoostMentions(config_dict=None)
         with patch.dict(os.environ, {}, clear=True), \
-             pytest.raises(ValueError, match="Unknown platform"):
+             pytest.raises(ValueError, match="PLATFORM environment variable is not set"):
             handler.set_up_config_dict()
 
     def test_pre_set_keys_are_not_overwritten(self):

--- a/tests/test_boost_tags.py
+++ b/tests/test_boost_tags.py
@@ -1,0 +1,557 @@
+# pylint: disable=missing-class-docstring,missing-function-docstring,protected-access
+# pylint: disable=unused-argument,attribute-defined-outside-init,too-few-public-methods
+# pylint: disable=too-many-arguments,import-outside-toplevel
+"""
+Tests for src/boost_tags.py
+
+Covers:
+- cfg property: raises RuntimeError when config_dict is None
+- set_up_config_dict: Bluesky/Mastodon key population, setdefault semantics
+  (pre-set values preserved), TAGS_TO_BOOST parsing, missing/unknown platform errors
+- _boost_tags_mastodon: raises NotImplementedError
+- _boost_tags_bluesky: repost happy path, dedup via seen_cids, dry-run mode,
+  max_boosts_per_run cap, tag normalisation, facet-first extraction, text
+  fallback with punctuation stripping, AtProtocolError handling,
+  InvokeTimeoutError at login/timeline/search
+- boost_tags: platform routing and logging
+"""
+
+import logging
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from boost_tags import BoostTags
+
+try:
+    from atproto.exceptions import AtProtocolError
+    from atproto_client.exceptions import InvokeTimeoutError
+except ImportError:  # pragma: no cover
+    import boost_tags as _bt
+    AtProtocolError = _bt.AtProtocolError  # type: ignore[attr-defined]
+    InvokeTimeoutError = _bt.InvokeTimeoutError  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+BASE_BLUESKY_CONFIG = {
+    "platform": "bluesky",
+    "password": "pw",
+    "username": "bot.bsky.social",
+    "client_name": "rladies_bot",
+    "api_base_url": "https://bsky.social",
+    "tags": ["rstats"],
+    "max_boosts_per_run": 5,
+}
+
+BASE_MASTODON_CONFIG = {
+    "platform": "mastodon",
+    "password": "pw",
+    "username": "bot@example.social",
+    "client_name": "rladies_bot",
+    "api_base_url": "https://botsin.space",
+    "mastodon_visibility": "public",
+    "access_token": "atoken",
+    "client_cred_file": "cred.secret",
+    "timeline_depth_limit": 40,
+    "tags": ["rstats"],
+    "max_boosts_per_run": 5,
+}
+
+
+def make_handler(config=None, no_dry_run=True):
+    """Return a BoostTags instance pre-loaded with a config dict."""
+    return BoostTags(config_dict=dict(config) if config else None, no_dry_run=no_dry_run)
+
+
+def _bluesky_post(
+    *,
+    cid="cid-abc",
+    uri="at://uri-abc",
+    handle="someone.bsky.social",
+    text="#rstats great post",
+    facets=None,
+):
+    """Build a minimal Bluesky post stub."""
+    post = MagicMock()
+    post.cid = cid
+    post.uri = uri
+    post.author.handle = handle
+    post.record.text = text
+    post.record.facets = facets
+    return post
+
+
+def _facet_with_tag(tag: str):
+    """Build a mock ATProto facet whose single feature carries the given tag."""
+    feature = MagicMock(spec=["tag"])
+    feature.tag = tag
+    facet = MagicMock()
+    facet.features = [feature]
+    return facet
+
+
+def _make_bluesky_client(*, seen_cids=None, posts_by_tag=None):
+    """
+    Build a mock Bluesky client.
+
+    seen_cids    – CIDs already in the timeline (treated as already-seen).
+    posts_by_tag – mapping of normalised tag string → list of post stubs.
+    """
+    seen_cids = seen_cids or []
+    posts_by_tag = posts_by_tag or {}
+
+    client = MagicMock()
+
+    feed_items = []
+    for cid in seen_cids:
+        item = MagicMock()
+        item.post.cid = cid
+        feed_items.append(item)
+    client.get_timeline.return_value.feed = feed_items
+
+    def _search(params):
+        tag = params.get("q", "")
+        response = MagicMock()
+        response.posts = posts_by_tag.get(tag, [])
+        return response
+
+    client.app.bsky.feed.search_posts.side_effect = _search
+    return client
+
+
+# ---------------------------------------------------------------------------
+# cfg property
+# ---------------------------------------------------------------------------
+
+
+class TestCfgProperty:
+    def test_raises_when_config_dict_is_none(self):
+        # Accessing cfg before set_up_config_dict must raise, not silently return None
+        handler = BoostTags(config_dict=None)
+        with pytest.raises(RuntimeError, match="config_dict is not set"):
+            _ = handler.cfg
+
+    def test_returns_dict_when_set(self):
+        handler = BoostTags(config_dict={"key": "value"})
+        assert handler.cfg == {"key": "value"}
+
+
+# ---------------------------------------------------------------------------
+# set_up_config_dict
+# ---------------------------------------------------------------------------
+
+
+class TestSetUpConfigDict:
+    def test_missing_platform_raises_value_error(self):
+        # A completely absent PLATFORM env var must fail loudly
+        handler = BoostTags(config_dict=None)
+        with patch.dict(os.environ, {}, clear=True), \
+             pytest.raises(ValueError, match="PLATFORM environment variable is not set"):
+            handler.set_up_config_dict()
+
+    def test_unknown_platform_raises_value_error(self):
+        # An unsupported PLATFORM value must raise rather than silently do nothing
+        handler = BoostTags(config_dict=None)
+        with patch.dict(os.environ, {"PLATFORM": "twitter"}, clear=True), \
+             pytest.raises(ValueError, match="Unknown platform"):
+            handler.set_up_config_dict()
+
+    def test_bluesky_populates_api_base_url(self):
+        env = {"PLATFORM": "bluesky", "PASSWORD": "pw",
+               "USERNAME": "u", "CLIENT_NAME": "bot"}
+        handler = BoostTags(config_dict=None)
+        with patch.dict(os.environ, env, clear=True):
+            handler.set_up_config_dict()
+
+        assert handler.config_dict["api_base_url"] == "https://bsky.social"
+
+    def test_mastodon_populates_required_keys(self):
+        env = {
+            "PLATFORM": "mastodon",
+            "PASSWORD": "secret",
+            "USERNAME": "user@social",
+            "CLIENT_NAME": "rladies_bot",
+            "ACCESS_TOKEN": "tok",
+            "BOT_CLIENTCRED_SECRET": "cred.secret",
+        }
+        handler = BoostTags(config_dict=None)
+        with patch.dict(os.environ, env, clear=True), \
+             patch("boost_tags.config") as mock_cfg:
+            mock_cfg.MASTODON_VISIBILITY = "public"
+            mock_cfg.API_BASE_URL = "https://botsin.space"
+            handler.set_up_config_dict()
+
+        assert handler.config_dict["mastodon_visibility"] == "public"
+        assert handler.config_dict["api_base_url"] == "https://botsin.space"
+        assert handler.config_dict["access_token"] == "tok"
+        assert handler.config_dict["client_cred_file"] == "cred.secret"
+        assert handler.config_dict["timeline_depth_limit"] == 40
+
+    def test_pre_set_keys_are_not_overwritten(self):
+        # setdefault semantics: values already in config_dict must survive
+        cfg = {
+            "platform": "bluesky",
+            "api_base_url": "https://custom.endpoint",
+            "password": "pw",
+            "username": "u",
+            "client_name": "bot",
+        }
+        handler = BoostTags(config_dict=cfg)
+        with patch.dict(os.environ, {}, clear=True):
+            handler.set_up_config_dict()
+
+        assert handler.config_dict["api_base_url"] == "https://custom.endpoint"
+
+    def test_empty_tags_to_boost_produces_empty_list(self):
+        # "".split(",") yields [""]; the filter must drop that blank entry
+        env = {"PLATFORM": "bluesky", "TAGS_TO_BOOST": ""}
+        handler = BoostTags(config_dict=None)
+        with patch.dict(os.environ, env, clear=True):
+            handler.set_up_config_dict()
+
+        assert handler.config_dict["tags"] == []
+
+    def test_tags_to_boost_parsed_and_whitespace_stripped(self):
+        env = {"PLATFORM": "bluesky", "TAGS_TO_BOOST": " rstats , rladies , python "}
+        handler = BoostTags(config_dict=None)
+        with patch.dict(os.environ, env, clear=True):
+            handler.set_up_config_dict()
+
+        assert handler.config_dict["tags"] == ["rstats", "rladies", "python"]
+
+    def test_max_boosts_per_run_defaults_to_5(self):
+        env = {"PLATFORM": "bluesky"}
+        handler = BoostTags(config_dict=None)
+        with patch.dict(os.environ, env, clear=True):
+            handler.set_up_config_dict()
+
+        assert handler.config_dict["max_boosts_per_run"] == 5
+
+    def test_config_dict_none_initialised_to_dict(self):
+        # Starting from None must produce a populated dict, not crash
+        env = {"PLATFORM": "bluesky", "PASSWORD": "pw",
+               "USERNAME": "u", "CLIENT_NAME": "bot"}
+        handler = BoostTags(config_dict=None)
+        with patch.dict(os.environ, env, clear=True):
+            handler.set_up_config_dict()
+
+        assert isinstance(handler.config_dict, dict)
+
+    def test_platform_from_env_is_lowercased(self):
+        env = {"PLATFORM": "BLUESKY"}
+        handler = BoostTags(config_dict=None)
+        with patch.dict(os.environ, env, clear=True):
+            handler.set_up_config_dict()
+
+        assert handler.config_dict["platform"] == "bluesky"
+
+
+# ---------------------------------------------------------------------------
+# _boost_tags_mastodon
+# ---------------------------------------------------------------------------
+
+
+class TestBoostTagsMastodon:
+    def test_raises_not_implemented_error(self):
+        # Mastodon must fail loudly so a misconfigured bot is never silent
+        handler = make_handler(config=BASE_MASTODON_CONFIG)
+        with pytest.raises(NotImplementedError, match="Mastodon tag boosting"):
+            handler._boost_tags_mastodon()
+
+
+# ---------------------------------------------------------------------------
+# _boost_tags_bluesky
+# ---------------------------------------------------------------------------
+
+
+class TestBoostTagsBluesky:
+    def _run(self, handler, client):
+        with patch("boost_tags.login_bluesky", return_value=client), \
+             patch("boost_tags.time.sleep"):
+            handler._boost_tags_bluesky()
+        return client
+
+    def test_reposts_matching_post(self):
+        # Happy path: a post that matches the tag and is not in seen_cids gets reposted
+        handler = make_handler(config=BASE_BLUESKY_CONFIG)
+        post = _bluesky_post(cid="new-cid", text="#rstats great post")
+        client = _make_bluesky_client(posts_by_tag={"rstats": [post]})
+        self._run(handler, client)
+        client.repost.assert_called_once_with(uri=post.uri, cid="new-cid")
+
+    def test_skips_post_already_in_seen_cids(self):
+        # A post already in the timeline must never be reposted
+        handler = make_handler(config=BASE_BLUESKY_CONFIG)
+        post = _bluesky_post(cid="already-seen", text="#rstats hello")
+        client = _make_bluesky_client(
+            seen_cids=["already-seen"],
+            posts_by_tag={"rstats": [post]},
+        )
+        self._run(handler, client)
+        client.repost.assert_not_called()
+
+    def test_seen_cids_updated_prevents_duplicate_repost(self):
+        # The same post appearing under two different tags must only be reposted once
+        cfg = {**BASE_BLUESKY_CONFIG, "tags": ["rstats", "rladies"]}
+        handler = make_handler(config=cfg)
+        post = _bluesky_post(cid="shared-cid", text="#rstats #rladies")
+        client = _make_bluesky_client(
+            posts_by_tag={"rstats": [post], "rladies": [post]}
+        )
+        self._run(handler, client)
+        assert client.repost.call_count == 1
+
+    def test_dry_run_does_not_call_repost(self):
+        handler = make_handler(config=BASE_BLUESKY_CONFIG, no_dry_run=False)
+        post = _bluesky_post(cid="cid-1", text="#rstats hello")
+        client = _make_bluesky_client(posts_by_tag={"rstats": [post]})
+        self._run(handler, client)
+        client.repost.assert_not_called()
+
+    def test_dry_run_logs_dry_run_message(self, caplog):
+        handler = make_handler(config=BASE_BLUESKY_CONFIG, no_dry_run=False)
+        post = _bluesky_post(cid="cid-1", text="#rstats hello")
+        client = _make_bluesky_client(posts_by_tag={"rstats": [post]})
+        with caplog.at_level(logging.INFO, logger="boost_tags"):
+            self._run(handler, client)
+        assert "[DRY RUN]" in caplog.text
+
+    def test_dry_run_updates_seen_cids_to_prevent_double_log(self):
+        # Even in dry-run mode, seen_cids must be updated so the same post is
+        # not logged twice when it appears under multiple tags
+        cfg = {**BASE_BLUESKY_CONFIG, "tags": ["rstats", "rladies"]}
+        handler = make_handler(config=cfg, no_dry_run=False)
+        post = _bluesky_post(cid="shared-cid", text="#rstats #rladies")
+        client = _make_bluesky_client(
+            posts_by_tag={"rstats": [post], "rladies": [post]}
+        )
+        with patch("boost_tags.login_bluesky", return_value=client), \
+             patch("boost_tags.time.sleep") as mock_sleep:
+            handler._boost_tags_bluesky()
+        # sleep is only called once (one qualifying post, not two)
+        assert mock_sleep.call_count == 1
+
+    def test_atprotoerror_logged_as_error_and_loop_continues(self, caplog):
+        # A failing repost must be logged at ERROR and must not abort subsequent posts
+        cfg = {**BASE_BLUESKY_CONFIG, "tags": ["rstats"]}
+        handler = make_handler(config=cfg)
+        post_fail = _bluesky_post(cid="cid-1", text="#rstats")
+        post_ok   = _bluesky_post(cid="cid-2", text="#rstats")
+        client = _make_bluesky_client(posts_by_tag={"rstats": [post_fail, post_ok]})
+        client.repost.side_effect = [AtProtocolError("rate limit"), MagicMock()]
+
+        with patch("boost_tags.login_bluesky", return_value=client), \
+             patch("boost_tags.time.sleep"), \
+             caplog.at_level(logging.ERROR, logger="boost_tags"):
+            handler._boost_tags_bluesky()
+
+        assert any(r.levelname == "ERROR" for r in caplog.records)
+        assert client.repost.call_count == 2
+
+    def test_max_boosts_per_run_caps_reposts(self):
+        cfg = {**BASE_BLUESKY_CONFIG, "max_boosts_per_run": 2}
+        handler = make_handler(config=cfg)
+        posts = [_bluesky_post(cid=f"cid-{i}", text="#rstats") for i in range(5)]
+        client = _make_bluesky_client(posts_by_tag={"rstats": posts})
+        self._run(handler, client)
+        assert client.repost.call_count == 2
+
+    def test_max_boosts_per_run_respected_across_tags(self):
+        # The cap applies globally across all tags, not per-tag
+        cfg = {**BASE_BLUESKY_CONFIG, "tags": ["rstats", "rladies"], "max_boosts_per_run": 2}
+        handler = make_handler(config=cfg)
+        rstats_posts  = [_bluesky_post(cid=f"r-{i}", text="#rstats")  for i in range(3)]
+        rladies_posts = [_bluesky_post(cid=f"l-{i}", text="#rladies") for i in range(3)]
+        client = _make_bluesky_client(
+            posts_by_tag={"rstats": rstats_posts, "rladies": rladies_posts}
+        )
+        self._run(handler, client)
+        assert client.repost.call_count == 2
+
+    def test_max_boosts_logs_stop_message(self, caplog):
+        cfg = {**BASE_BLUESKY_CONFIG, "tags": ["rstats", "rladies"], "max_boosts_per_run": 1}
+        handler = make_handler(config=cfg)
+        posts = [_bluesky_post(cid="cid-1", text="#rstats")]
+        client = _make_bluesky_client(posts_by_tag={"rstats": posts})
+        with caplog.at_level(logging.INFO, logger="boost_tags"):
+            self._run(handler, client)
+        assert "max boosts per run" in caplog.text.lower()
+
+    def test_tag_normalised_lowercased_and_hash_stripped(self):
+        # Tags like "#RStats" or "  RStats  " must be normalised before matching
+        cfg = {**BASE_BLUESKY_CONFIG, "tags": ["#RStats"]}
+        handler = make_handler(config=cfg)
+        post = _bluesky_post(cid="cid-1", text="#rstats great")
+        # The search_posts mock must match the normalised key "rstats"
+        client = _make_bluesky_client(posts_by_tag={"rstats": [post]})
+        self._run(handler, client)
+        client.repost.assert_called_once()
+
+    def test_facets_used_for_tag_extraction(self):
+        # Structured ATProto facets are the primary source of tags
+        handler = make_handler(config=BASE_BLUESKY_CONFIG)
+        facet = _facet_with_tag("rstats")
+        # Text has NO "#rstats" — relies purely on facets
+        post = _bluesky_post(cid="cid-1", text="no hashtag here", facets=[facet])
+        client = _make_bluesky_client(posts_by_tag={"rstats": [post]})
+        self._run(handler, client)
+        client.repost.assert_called_once()
+
+    def test_falls_back_to_text_when_no_facets(self):
+        # When facets is None/empty the code must fall back to text parsing
+        handler = make_handler(config=BASE_BLUESKY_CONFIG)
+        post = _bluesky_post(cid="cid-1", text="#rstats fallback post", facets=None)
+        client = _make_bluesky_client(posts_by_tag={"rstats": [post]})
+        self._run(handler, client)
+        client.repost.assert_called_once()
+
+    def test_text_parsing_strips_trailing_punctuation(self):
+        # Tags like "#rstats." or "#rstats," (common on social media) must still match
+        handler = make_handler(config=BASE_BLUESKY_CONFIG)
+        post = _bluesky_post(cid="cid-1", text="#rstats. Nice work!", facets=None)
+        client = _make_bluesky_client(posts_by_tag={"rstats": [post]})
+        self._run(handler, client)
+        client.repost.assert_called_once()
+
+    def test_post_not_reposted_if_tag_absent_from_post(self):
+        # search_posts can return posts that don't actually contain the tag — skip them
+        handler = make_handler(config=BASE_BLUESKY_CONFIG)
+        post = _bluesky_post(cid="cid-1", text="no relevant hashtag here", facets=None)
+        client = _make_bluesky_client(posts_by_tag={"rstats": [post]})
+        self._run(handler, client)
+        client.repost.assert_not_called()
+
+    def test_empty_tags_list_makes_no_search_calls(self):
+        cfg = {**BASE_BLUESKY_CONFIG, "tags": []}
+        handler = make_handler(config=cfg)
+        client = _make_bluesky_client()
+        self._run(handler, client)
+        client.app.bsky.feed.search_posts.assert_not_called()
+
+    def test_invoke_timeout_on_login_returns_early(self, caplog):
+        # A timeout during login must log an error and return, not raise
+        handler = make_handler(config=BASE_BLUESKY_CONFIG)
+        with patch("boost_tags.login_bluesky", side_effect=InvokeTimeoutError), \
+             patch("boost_tags.time.sleep"), \
+             caplog.at_level(logging.ERROR, logger="boost_tags"):
+            handler._boost_tags_bluesky()
+        assert any(r.levelname == "ERROR" for r in caplog.records)
+
+    def test_invoke_timeout_on_login_makes_no_search_calls(self):
+        handler = make_handler(config=BASE_BLUESKY_CONFIG)
+        client = MagicMock()
+        with patch("boost_tags.login_bluesky", side_effect=InvokeTimeoutError), \
+             patch("boost_tags.time.sleep"):
+            handler._boost_tags_bluesky()
+        client.app.bsky.feed.search_posts.assert_not_called()
+
+    def test_invoke_timeout_on_timeline_returns_early(self, caplog):
+        # A timeout fetching the timeline must abort without searching any tags
+        handler = make_handler(config=BASE_BLUESKY_CONFIG)
+        client = MagicMock()
+        client.get_timeline.side_effect = InvokeTimeoutError
+        with patch("boost_tags.login_bluesky", return_value=client), \
+             patch("boost_tags.time.sleep"), \
+             caplog.at_level(logging.ERROR, logger="boost_tags"):
+            handler._boost_tags_bluesky()
+        client.app.bsky.feed.search_posts.assert_not_called()
+        assert any(r.levelname == "ERROR" for r in caplog.records)
+
+    def test_invoke_timeout_on_search_skips_tag_and_continues(self):
+        # A timeout on one tag's search must skip it and continue to the next tag
+        cfg = {**BASE_BLUESKY_CONFIG, "tags": ["rstats", "rladies"]}
+        handler = make_handler(config=cfg)
+        rladies_post = _bluesky_post(cid="cid-rladies", text="#rladies great")
+
+        client = MagicMock()
+        client.get_timeline.return_value.feed = []
+
+        def _search(params):
+            if params["q"] == "rstats":
+                raise InvokeTimeoutError
+            response = MagicMock()
+            response.posts = [rladies_post]
+            return response
+
+        client.app.bsky.feed.search_posts.side_effect = _search
+
+        with patch("boost_tags.login_bluesky", return_value=client), \
+             patch("boost_tags.time.sleep"):
+            handler._boost_tags_bluesky()
+
+        # "rstats" timed out, "rladies" should still have been reposted
+        client.repost.assert_called_once_with(uri=rladies_post.uri, cid="cid-rladies")
+
+    def test_time_sleep_called_between_reposts(self):
+        # sleep(0.1) must be called once per qualifying post to avoid hammering the API
+        cfg = {**BASE_BLUESKY_CONFIG, "max_boosts_per_run": 10}
+        handler = make_handler(config=cfg)
+        posts = [_bluesky_post(cid=f"cid-{i}", text="#rstats") for i in range(3)]
+        client = _make_bluesky_client(posts_by_tag={"rstats": posts})
+
+        with patch("boost_tags.login_bluesky", return_value=client), \
+             patch("boost_tags.time.sleep") as mock_sleep:
+            handler._boost_tags_bluesky()
+
+        assert mock_sleep.call_count == 3
+
+    def test_empty_feed_still_processes_tags(self):
+        # An empty timeline (no seen_cids) must not crash and must process tags normally
+        handler = make_handler(config=BASE_BLUESKY_CONFIG)
+        post = _bluesky_post(cid="fresh-cid", text="#rstats")
+        client = _make_bluesky_client(seen_cids=[], posts_by_tag={"rstats": [post]})
+        self._run(handler, client)
+        client.repost.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# boost_tags (orchestration)
+# ---------------------------------------------------------------------------
+
+
+class TestBoostTags:
+    def test_routes_to_bluesky(self):
+        handler = BoostTags(config_dict=None)
+        with patch.object(handler, "set_up_config_dict"), \
+             patch.object(handler, "_boost_tags_mastodon") as mock_mastodon, \
+             patch.object(handler, "_boost_tags_bluesky") as mock_bluesky:
+            handler.config_dict = dict(BASE_BLUESKY_CONFIG)
+            handler.boost_tags()
+
+        mock_bluesky.assert_called_once()
+        mock_mastodon.assert_not_called()
+
+    def test_routes_to_mastodon(self):
+        handler = BoostTags(config_dict=None)
+        with patch.object(handler, "set_up_config_dict"), \
+             patch.object(handler, "_boost_tags_mastodon") as mock_mastodon, \
+             patch.object(handler, "_boost_tags_bluesky") as mock_bluesky:
+            handler.config_dict = dict(BASE_MASTODON_CONFIG)
+            handler.boost_tags()
+
+        mock_mastodon.assert_called_once()
+        mock_bluesky.assert_not_called()
+
+    def test_logs_client_name_and_api_base_url(self, caplog):
+        handler = BoostTags(config_dict=None)
+        with patch.object(handler, "set_up_config_dict"), \
+             patch.object(handler, "_boost_tags_bluesky"), \
+             caplog.at_level(logging.INFO, logger="boost_tags"):
+            handler.config_dict = dict(BASE_BLUESKY_CONFIG)
+            handler.boost_tags()
+
+        assert "rladies_bot" in caplog.text
+        assert "https://bsky.social" in caplog.text
+
+    def test_calls_set_up_config_dict(self):
+        handler = BoostTags(config_dict=None)
+        with patch.object(handler, "set_up_config_dict") as mock_setup, \
+             patch.object(handler, "_boost_tags_bluesky"):
+            handler.config_dict = dict(BASE_BLUESKY_CONFIG)
+            handler.boost_tags()
+
+        mock_setup.assert_called_once()

--- a/tests/test_boost_tags.py
+++ b/tests/test_boost_tags.py
@@ -283,6 +283,24 @@ class TestBoostTagsBluesky:
         self._run(handler, client)
         client.repost.assert_called_once_with(uri=post.uri, cid="new-cid")
 
+    def test_skips_own_posts(self):
+        # The bot must never repost its own posts
+        cfg = {**BASE_BLUESKY_CONFIG, "username": "bot.bsky.social"}
+        handler = make_handler(config=cfg)
+        post = _bluesky_post(cid="own-cid", text="#rstats", handle="bot.bsky.social")
+        client = _make_bluesky_client(posts_by_tag={"rstats": [post]})
+        self._run(handler, client)
+        client.repost.assert_not_called()
+
+    def test_skips_own_posts_case_insensitive(self):
+        # Handle comparison must be case-insensitive
+        cfg = {**BASE_BLUESKY_CONFIG, "username": "Bot.Bsky.Social"}
+        handler = make_handler(config=cfg)
+        post = _bluesky_post(cid="own-cid", text="#rstats", handle="bot.bsky.social")
+        client = _make_bluesky_client(posts_by_tag={"rstats": [post]})
+        self._run(handler, client)
+        client.repost.assert_not_called()
+
     def test_skips_post_already_in_seen_cids(self):
         # A post already in the timeline must never be reposted
         handler = make_handler(config=BASE_BLUESKY_CONFIG)

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -38,20 +38,6 @@ def make_debug(bot='pyladies', platform='bluesky', what_to_debug='blog', no_dry_
 # __init__ defaults
 # ---------------------------------------------------------------------------
 
-class TestInit:
-    def test_default_bot(self):
-        assert DebugBots().bot == 'pyladies'
-
-    def test_default_platform(self):
-        assert DebugBots().platform == 'bluesky'
-
-    def test_default_what_to_debug(self):
-        assert DebugBots().what_to_debug == 'blog'
-
-    def test_default_no_dry_run_is_false(self):
-        # False = dry-run is active by default; nothing is actually posted
-        assert DebugBots().no_dry_run is False
-
 
 # ---------------------------------------------------------------------------
 # get_config_blog
@@ -131,7 +117,7 @@ class TestGetConfigBlog:
 class TestGetConfigBoost:
     def test_pyladies_bluesky_tags(self):
         cfg = make_debug(bot='pyladies', platform='bluesky').get_config_boost()
-        assert cfg['tags'] == 'pyladies'
+        assert cfg['tags'] == ['pyladies']
 
     def test_pyladies_bluesky_client_name(self):
         cfg = make_debug(bot='pyladies', platform='bluesky').get_config_boost()
@@ -139,7 +125,7 @@ class TestGetConfigBoost:
 
     def test_pyladies_mastodon_tags(self):
         cfg = make_debug(bot='pyladies', platform='mastodon').get_config_boost()
-        assert cfg['tags'] == 'pyladies'
+        assert cfg['tags'] == ['pyladies']
 
     def test_pyladies_mastodon_has_access_token_key(self):
         cfg = make_debug(bot='pyladies', platform='mastodon').get_config_boost()
@@ -147,7 +133,7 @@ class TestGetConfigBoost:
 
     def test_rladies_bluesky_tags(self):
         cfg = make_debug(bot='rladies', platform='bluesky').get_config_boost()
-        assert cfg['tags'] == 'rladies'
+        assert cfg['tags'] == ['rladies']
 
     def test_rladies_bluesky_client_name(self):
         cfg = make_debug(bot='rladies', platform='bluesky').get_config_boost()
@@ -163,7 +149,7 @@ class TestGetConfigBoost:
 
     def test_rladies_mastodon_tags(self):
         cfg = make_debug(bot='rladies', platform='mastodon').get_config_boost()
-        assert cfg['tags'] == 'rladies'
+        assert cfg['tags'] == ['rladies']
 
     def test_rladies_mastodon_has_access_token_key(self):
         cfg = make_debug(bot='rladies', platform='mastodon').get_config_boost()


### PR DESCRIPTION
# What this PR is about

*Align boost_tags with boost_mentions patterns and fix pitfalls*

- Replace _load_config_from_env with set_up_config_dict using setdefault,
  matching boost_mentions conventions
- Add cfg property to guard against uninitialized config_dict
- Raise ValueError when PLATFORM env var is missing (both files) instead of
  silently passing an empty string into the platform branch logic
- Fix api_base_url for Bluesky: was the literal string "bluesky", now "https://bsky.social"
- Raise NotImplementedError in _boost_tags_mastodon so misconfigured bots fail loudly
- Fix empty TAGS_TO_BOOST producing [""] by filtering blank entries after split
- Add max_boosts_per_run limit and dry-run logging inside the post loop
- Fix seen_cids not being updated after a successful repost (duplicate boost risk)
- Replace fragile whitespace-split tag extraction with ATProto facet parsing,
  falling back to text-split with punctuation stripping
- Drop dead public repost_tags_mastodon method and unused imports (urlparse)
- Add logging.basicConfig in __main__ block

#44 