### PR TITLE
Fix workflows to respect protected main branch

### DIFF
--- a/.github/workflows/pyladies_anniversaries.yml
+++ b/.github/workflows/pyladies_anniversaries.yml
@@ -11,6 +11,7 @@ jobs:
     
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout repo content
@@ -51,23 +52,21 @@ jobs:
           USERNAME: ${{ secrets.PYLADIES_BSKY_USERNAME }}
         run: python src/promote_anniversaries.py
 
-      - name: Commit files
-        id: commit
-        run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "github-actions"
-          git add --all
-          if [ -z "$(git status --porcelain)" ]; then
-            echo "push=false" >> $GITHUB_OUTPUT
-          else
-            git commit -m "Automated anniversary update" -a
-            echo "push=true" >> $GITHUB_OUTPUT
-          fi
-        shell: bash
-
       - name: Push changes
-        if: steps.commit.outputs.push == 'true'
-        uses: ad-m/github-push-action@master
+        id: cpr
+        uses: peter-evans/create-pull-request@v7
         with:
-          github_token: ${{ secrets.SECRET_WRITE }}
-          branch: main
+          token: ${{ secrets.SECRET_WRITE }}
+          commit-message: "Automated anniversary update"
+          branch: bot/pyladies-anniversary-update
+          delete-branch: true
+          title: "Update PyLadies anniversary data"
+          body: "Automated anniversary update."
+
+      - name: Auto-merge PR
+        if: steps.cpr.outputs.pull-request-number != ''
+        uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          token: ${{ secrets.SECRET_WRITE }}
+          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
+          merge-method: squash

--- a/.github/workflows/pyladies_promote_blog.yml
+++ b/.github/workflows/pyladies_promote_blog.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - name: checkout repo content
@@ -59,23 +60,21 @@ jobs:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
         run: python src/promote_blog_post.py
   
-      - name: Commit files
-        id: commit
-        run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "github-actions"
-          git add --all
-          if [ -z "$(git status --porcelain)" ]; then
-            echo "push=false" >> $GITHUB_OUTPUT
-          else
-            git commit -m "Update blog post metadata" -a
-            echo "push=true" >> $GITHUB_OUTPUT
-          fi
-        shell: bash
-          
       - name: Push changes
-        if: steps.commit.outputs.push == 'true'
-        uses: ad-m/github-push-action@master
+        id: cpr
+        uses: peter-evans/create-pull-request@v7
         with:
-          github_token: ${{ secrets.SECRET_WRITE }}
-          branch: main
+          token: ${{ secrets.SECRET_WRITE }}
+          commit-message: "Update blog post metadata"
+          branch: bot/pyladies-blog-metadata
+          delete-branch: true
+          title: "Update PyLadies blog post metadata"
+          body: "Automated update of blog post counter and archive metadata."
+
+      - name: Auto-merge PR
+        if: steps.cpr.outputs.pull-request-number != ''
+        uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          token: ${{ secrets.SECRET_WRITE }}
+          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
+          merge-method: squash

--- a/.github/workflows/pyladies_rss_feed.yml
+++ b/.github/workflows/pyladies_rss_feed.yml
@@ -7,9 +7,14 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: checkout repo content
-        uses: actions/checkout@v2 # checkout the repository content
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.SECRET_WRITE }}
 
       - name: setup python
         uses: actions/setup-python@v4
@@ -28,26 +33,21 @@ jobs:
           JSON_FILE: "pyladies_meta_data.json"
         run: python src/get_rss_data.py
 
-      - name: Commit files
-        id: commit
-        run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "github-actions"
-          git add --all
-          if ! git diff-index --quiet HEAD --; then 
-            git commit -m "Add changes" -a
-            echo "::set-output name=push::true"
-          fi
-#          if [-z "$(git status --porcelain)"]; then
-#            echo "::set-output name=push::false"
-#          else
-#            git commit -m "Add changes" -a
-#            echo "::set-output name=push::true"
-#          fi
-        shell: bash
-        
       - name: Push changes
-        if: steps.commit.outputs.push == 'true'
-        uses: ad-m/github-push-action@master
+        id: cpr
+        uses: peter-evans/create-pull-request@v7
         with:
-          github_token: ${{ secrets.SECRET_WRITE }}
+          token: ${{ secrets.SECRET_WRITE }}
+          commit-message: "Update PyLadies RSS feed metadata"
+          branch: bot/pyladies-rss-metadata
+          delete-branch: true
+          title: "Update PyLadies RSS feed metadata"
+          body: "Automated update of RSS feed metadata."
+
+      - name: Auto-merge PR
+        if: steps.cpr.outputs.pull-request-number != ''
+        uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          token: ${{ secrets.SECRET_WRITE }}
+          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
+          merge-method: squash

--- a/.github/workflows/rladies_anniversaries.yml
+++ b/.github/workflows/rladies_anniversaries.yml
@@ -11,6 +11,7 @@ jobs:
     
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout repo content
@@ -52,23 +53,21 @@ jobs:
           USERNAME: ${{ secrets.RLADIES_BSKY_USERNAME }}
         run: python src/promote_anniversaries.py
 
-      - name: Commit files
-        id: commit
-        run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "github-actions"
-          git add --all
-          if [ -z "$(git status --porcelain)" ]; then
-            echo "push=false" >> $GITHUB_OUTPUT
-          else
-            git commit -m "Automated anniversary update" -a
-            echo "push=true" >> $GITHUB_OUTPUT
-          fi
-        shell: bash
-
       - name: Push changes
-        if: steps.commit.outputs.push == 'true'
-        uses: ad-m/github-push-action@master
+        id: cpr
+        uses: peter-evans/create-pull-request@v7
         with:
-          github_token: ${{ secrets.SECRET_WRITE }}
-          branch: main
+          token: ${{ secrets.SECRET_WRITE }}
+          commit-message: "Automated anniversary update"
+          branch: bot/rladies-anniversary-update
+          delete-branch: true
+          title: "Update RLadies anniversary data"
+          body: "Automated anniversary update."
+
+      - name: Auto-merge PR
+        if: steps.cpr.outputs.pull-request-number != ''
+        uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          token: ${{ secrets.SECRET_WRITE }}
+          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
+          merge-method: squash

--- a/.github/workflows/rladies_promote_blog.yml
+++ b/.github/workflows/rladies_promote_blog.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - name: checkout repo content
@@ -59,23 +60,21 @@ jobs:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
         run: python src/promote_blog_post.py
   
-      - name: Commit files
-        id: commit
-        run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "github-actions"
-          git add --all
-          if [ -z "$(git status --porcelain)" ]; then
-            echo "push=false" >> $GITHUB_OUTPUT
-          else
-            git commit -m "Update blog post metadata" -a
-            echo "push=true" >> $GITHUB_OUTPUT
-          fi
-        shell: bash
-          
       - name: Push changes
-        if: steps.commit.outputs.push == 'true'
-        uses: ad-m/github-push-action@master
+        id: cpr
+        uses: peter-evans/create-pull-request@v7
         with:
-          github_token: ${{ secrets.SECRET_WRITE }}
-          branch: main
+          token: ${{ secrets.SECRET_WRITE }}
+          commit-message: "Update blog post metadata"
+          branch: bot/rladies-blog-metadata
+          delete-branch: true
+          title: "Update RLadies blog post metadata"
+          body: "Automated update of blog post counter and archive metadata."
+
+      - name: Auto-merge PR
+        if: steps.cpr.outputs.pull-request-number != ''
+        uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          token: ${{ secrets.SECRET_WRITE }}
+          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
+          merge-method: squash

--- a/.github/workflows/rladies_rss_feed.yml
+++ b/.github/workflows/rladies_rss_feed.yml
@@ -7,9 +7,14 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: checkout repo content
-        uses: actions/checkout@v2 # checkout the repository content
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.SECRET_WRITE }}
 
       - name: setup python
         uses: actions/setup-python@v4
@@ -28,26 +33,21 @@ jobs:
           JSON_FILE: "rladies_meta_data.json"
         run: python src/get_rss_data.py
 
-      - name: Commit files
-        id: commit
-        run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "github-actions"
-          git add --all
-          if ! git diff-index --quiet HEAD --; then 
-            git commit -m "Add changes" -a
-            echo "::set-output name=push::true"
-          fi
-#          if [-z "$(git status --porcelain)"]; then
-#            echo "::set-output name=push::false"
-#          else
-#            git commit -m "Add changes" -a
-#            echo "::set-output name=push::true"
-#          fi
-        shell: bash
-        
       - name: Push changes
-        if: steps.commit.outputs.push == 'true'
-        uses: ad-m/github-push-action@master
+        id: cpr
+        uses: peter-evans/create-pull-request@v7
         with:
-          github_token: ${{ secrets.SECRET_WRITE }}
+          token: ${{ secrets.SECRET_WRITE }}
+          commit-message: "Update RLadies RSS feed metadata"
+          branch: bot/rladies-rss-metadata
+          delete-branch: true
+          title: "Update RLadies RSS feed metadata"
+          body: "Automated update of RSS feed metadata."
+
+      - name: Auto-merge PR
+        if: steps.cpr.outputs.pull-request-number != ''
+        uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          token: ${{ secrets.SECRET_WRITE }}
+          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
+          merge-method: squash


### PR DESCRIPTION
# What this PR is about

- Replace direct pushes to main with create-pull-request + enable-pull-request-automerge. 
- Bot runs now open a PR on a dedicated branch and auto-merge it, satisfying branch protection while requiring no manual intervention. 
- Bad runs leave an open PR as a visible signal rather than corrupting main.
