### PR TITLE
fix: remove rss_feed_youtube in favour of unified rss_feed

### DIFF
--- a/src/get_rss_data.py
+++ b/src/get_rss_data.py
@@ -134,6 +134,8 @@ class RSSData:
 
         The method collects:
         - `name`: The author's name (first entry in `authors`).
+        - `content_type`: Content type string (`"blog"`, `"youtube"`, or
+            `"podcast"`). Defaults to `"blog"` when absent.
         - `rss_feed`: List containing the `rss_feed` URL, or empty list if
             not set.
         - `mastodon`: Author's Mastodon handle if available.
@@ -147,6 +149,7 @@ class RSSData:
             dict: A dictionary containing metadata fields.
         """
         rss_feed = [url for url in [content.get("rss_feed")] if url]
+        content_type = content.get("type", "blog")
 
         author = content.get("authors", [{}])[0]
         name = author.get("name", "")
@@ -158,6 +161,7 @@ class RSSData:
 
         return {
             "name": name,
+            "content_type": content_type,
             "rss_feed": rss_feed,
             "mastodon": mastodon,
             "bluesky": bluesky,

--- a/src/get_rss_data.py
+++ b/src/get_rss_data.py
@@ -134,9 +134,8 @@ class RSSData:
 
         The method collects:
         - `name`: The author's name (first entry in `authors`).
-        - `rss_feed`: List of feed URLs, combining `rss_feed` and
-            `rss_feed_youtube` when both are present. Empty list if
-            neither is set.
+        - `rss_feed`: List containing the `rss_feed` URL, or empty list if
+            not set.
         - `mastodon`: Author's Mastodon handle if available.
         - `bluesky`: Author's Bluesky handle if available.
 
@@ -147,13 +146,7 @@ class RSSData:
         Returns:
             dict: A dictionary containing metadata fields.
         """
-        rss_feed = [
-            url for url in [
-                content.get("rss_feed"),
-                content.get("rss_feed_youtube"),
-            ]
-            if url
-        ]
+        rss_feed = [url for url in [content.get("rss_feed")] if url]
 
         author = content.get("authors", [{}])[0]
         name = author.get("name", "")

--- a/src/promote_blog_post.py
+++ b/src/promote_blog_post.py
@@ -20,6 +20,12 @@ from helper.login_bluesky import login_bluesky
 
 import config
 
+CONTENT_TYPE_EMOJI = {
+    "blog": "📝",
+    "youtube": "📺",
+    "podcast": "🎙️",
+}
+
 
 class PromoteBlogPost():
     """
@@ -342,14 +348,15 @@ class PromoteBlogPost():
         return None
 
     def build_post_mastodon(
-        self, title, name, platform_user_handle, tags, entry
+        self, title, name, platform_user_handle, tags, entry, content_type="blog"
     ):
         """
         Build Mastodon post.
         """
         platform_user_handle = self.check_platform_handle(platform_user_handle)
 
-        post = f'📝 "{title}"\n\n' if title else ''
+        emoji = CONTENT_TYPE_EMOJI.get(content_type, "📝")
+        post = f'{emoji} "{title}"\n\n' if title else ''
 
         if self.config_dict.get('gen_ai_support', None):
             summarized_blog_post = self.summarize_text(entry)
@@ -451,7 +458,8 @@ class PromoteBlogPost():
         name,
         platform_user_handle,
         tags,
-        entry
+        entry,
+        content_type="blog"
     ):
         """
         Build post for Bluesky.
@@ -467,12 +475,13 @@ class PromoteBlogPost():
         # Resolve DID once so _build() never makes a duplicate HTTP call
         did = self.get_bluesky_did(platform_user_handle) if platform_user_handle else None
 
+        emoji = CONTENT_TYPE_EMOJI.get(content_type, "📝")
         tag_list = [t.strip() for t in tags.split('#') if t.strip()]
 
         def _build(tag_subset):
             tb = client_utils.TextBuilder()
             if title:
-                tb.text(f'📝 "{title}"\n\n')
+                tb.text(f'{emoji} "{title}"\n\n')
             if summarized_blog_post:
                 tb.text(summarized_blog_post)
                 tb.text('\n\n')
@@ -506,6 +515,7 @@ class PromoteBlogPost():
 
         title = entry.get('title', '')
         name = feed.get('name', '')
+        content_type = feed.get('content_type', 'blog')
 
         if self.config_dict.get('platform', '') == 'mastodon':
             return self.build_post_mastodon(
@@ -513,7 +523,8 @@ class PromoteBlogPost():
                 name,
                 platform_user_handle,
                 tags,
-                entry
+                entry,
+                content_type,
             )
         if self.config_dict.get('platform', '') == 'bluesky':
             return self.build_post_bluesky(
@@ -521,7 +532,8 @@ class PromoteBlogPost():
                 name,
                 platform_user_handle,
                 tags,
-                entry
+                entry,
+                content_type,
             )
         return None
 

--- a/tests/test_get_rss_data.py
+++ b/tests/test_get_rss_data.py
@@ -30,7 +30,6 @@ def make_handler(config=None, no_dry_run=False):
 
 def make_content(
     rss_feed="https://example.com/feed.xml",
-    rss_feed_youtube=None,
     name="Alice",
     mastodon="@alice@fosstodon.org",
     bluesky="@alice.bsky.social",
@@ -45,8 +44,6 @@ def make_content(
     content = {}
     if rss_feed is not None:
         content["rss_feed"] = rss_feed
-    if rss_feed_youtube is not None:
-        content["rss_feed_youtube"] = rss_feed_youtube
     content["authors"] = [{"name": name, "social_media": [social]}]
     return content
 
@@ -98,47 +95,24 @@ class TestInit:
 
 class TestExtractInfo:
     def test_returns_rss_feed_as_single_item_list(self):
-        """rss_feed is returned as a one-element list when only rss_feed is set."""
-        content = make_content(rss_feed="https://example.com/feed.xml", rss_feed_youtube=None)
+        """rss_feed is returned as a one-element list when set."""
+        content = make_content(rss_feed="https://example.com/feed.xml")
         result = RSSData.extract_info(content)
         assert result["rss_feed"] == ["https://example.com/feed.xml"]
 
-    def test_returns_youtube_as_single_item_list_when_rss_feed_absent(self):
-        """rss_feed_youtube produces a one-element list when rss_feed is missing."""
-        content = make_content(rss_feed=None, rss_feed_youtube="https://yt.example.com/feed")
-        result = RSSData.extract_info(content)
-        assert result["rss_feed"] == ["https://yt.example.com/feed"]
-
-    def test_both_feeds_included_when_present(self):
-        """Both rss_feed and rss_feed_youtube are included when both are set."""
-        content = make_content(
-            rss_feed="https://example.com/feed.xml",
-            rss_feed_youtube="https://yt.example.com/feed",
-        )
-        result = RSSData.extract_info(content)
-        assert result["rss_feed"] == [
-            "https://example.com/feed.xml",
-            "https://yt.example.com/feed",
-        ]
-
-    def test_rss_feed_is_empty_list_when_both_absent(self):
-        """rss_feed is an empty list when both feed fields are missing."""
-        content = make_content(rss_feed=None, rss_feed_youtube=None)
+    def test_rss_feed_is_empty_list_when_absent(self):
+        """rss_feed is an empty list when the field is missing."""
+        content = make_content(rss_feed=None)
         result = RSSData.extract_info(content)
         assert result["rss_feed"] == []
 
     def test_rss_feed_type_is_always_list(self):
-        """rss_feed must always be a list."""
-        for rss, yt in [
-            ("https://example.com/feed.xml", None),
-            (None, "https://yt.example.com/feed"),
-            ("https://example.com/feed.xml", "https://yt.example.com/feed"),
-            (None, None),
-        ]:
-            content = make_content(rss_feed=rss, rss_feed_youtube=yt)
+        """rss_feed must always be a list regardless of whether it is set."""
+        for rss in ["https://example.com/feed.xml", None]:
+            content = make_content(rss_feed=rss)
             result = RSSData.extract_info(content)
             assert isinstance(result["rss_feed"], list), (
-                f"Expected list for rss={rss!r}, yt={yt!r}; got {type(result['rss_feed'])}"
+                f"Expected list for rss={rss!r}; got {type(result['rss_feed'])}"
             )
 
     def test_extracts_author_name(self):

--- a/tests/test_get_rss_data.py
+++ b/tests/test_get_rss_data.py
@@ -30,6 +30,7 @@ def make_handler(config=None, no_dry_run=False):
 
 def make_content(
     rss_feed="https://example.com/feed.xml",
+    content_type="blog",
     name="Alice",
     mastodon="@alice@fosstodon.org",
     bluesky="@alice.bsky.social",
@@ -44,6 +45,8 @@ def make_content(
     content = {}
     if rss_feed is not None:
         content["rss_feed"] = rss_feed
+    if content_type is not None:
+        content["type"] = content_type
     content["authors"] = [{"name": name, "social_media": [social]}]
     return content
 
@@ -197,14 +200,34 @@ class TestExtractInfo:
         assert result["mastodon"] == "@first@example.social"
 
     def test_completely_empty_content_dict(self):
-        """Fully empty dict must not raise; all fields default to ''."""
+        """Fully empty dict must not raise; all fields default."""
         result = RSSData.extract_info({})
-        assert result == {"name": "", "rss_feed": [], "mastodon": "", "bluesky": ""}
+        assert result == {"name": "", "content_type": "blog", "rss_feed": [], "mastodon": "", "bluesky": ""}
 
     def test_return_dict_has_expected_keys(self):
-        """Returned dict must always have exactly the four expected keys."""
+        """Returned dict must always have exactly the expected keys."""
         result = RSSData.extract_info(make_content())
-        assert set(result.keys()) == {"name", "rss_feed", "mastodon", "bluesky"}
+        assert set(result.keys()) == {"name", "content_type", "rss_feed", "mastodon", "bluesky"}
+
+    def test_extracts_content_type_blog(self):
+        """type=blog is passed through as content_type."""
+        result = RSSData.extract_info(make_content(content_type="blog"))
+        assert result["content_type"] == "blog"
+
+    def test_extracts_content_type_youtube(self):
+        """type=youtube is passed through as content_type."""
+        result = RSSData.extract_info(make_content(content_type="youtube"))
+        assert result["content_type"] == "youtube"
+
+    def test_extracts_content_type_podcast(self):
+        """type=podcast is passed through as content_type."""
+        result = RSSData.extract_info(make_content(content_type="podcast"))
+        assert result["content_type"] == "podcast"
+
+    def test_content_type_defaults_to_blog_when_absent(self):
+        """Missing type field defaults to 'blog'."""
+        result = RSSData.extract_info(make_content(content_type=None))
+        assert result["content_type"] == "blog"
 
 
 # ---------------------------------------------------------------------------
@@ -239,7 +262,7 @@ class TestGetMetaData:
         handler = make_handler()
         result = handler.get_meta_data([{}])
         assert len(result) == 1
-        assert result[0] == {"name": "", "rss_feed": [], "mastodon": "", "bluesky": ""}
+        assert result[0] == {"name": "", "content_type": "blog", "rss_feed": [], "mastodon": "", "bluesky": ""}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_promote_blog_post.py
+++ b/tests/test_promote_blog_post.py
@@ -698,7 +698,6 @@ class TestBuildPost:
         feed = {"name": "Author", "mastodon": None, "content_type": "youtube"}
         with patch.object(handler, "build_post_mastodon", return_value="post") as m:
             handler.build_post(entry, feed)
-        _, kwargs = m.call_args
         args = m.call_args[0]
         assert "youtube" in args
 

--- a/tests/test_promote_blog_post.py
+++ b/tests/test_promote_blog_post.py
@@ -508,6 +508,20 @@ class TestBuildPostMastodon:
         result = handler.build_post_mastodon("My Title", "", "", "#tag", entry)
         assert '📝 "My Title"' in result
 
+    def test_youtube_emoji(self):
+        handler = make_handler({"platform": "mastodon", "gen_ai_support": False})
+        entry = {"title": "My Video", "link": "https://x.com", "pub_date": "2024-01-01",
+                 "tags": [], "summary": "", "media_content": []}
+        result = handler.build_post_mastodon("My Video", "", "", "#tag", entry, content_type="youtube")
+        assert '📺 "My Video"' in result
+
+    def test_podcast_emoji(self):
+        handler = make_handler({"platform": "mastodon", "gen_ai_support": False})
+        entry = {"title": "My Episode", "link": "https://x.com", "pub_date": "2024-01-01",
+                 "tags": [], "summary": "", "media_content": []}
+        result = handler.build_post_mastodon("My Episode", "", "", "#tag", entry, content_type="podcast")
+        assert '🎙️ "My Episode"' in result
+
 
 # ---------------------------------------------------------------------------
 # build_post_bluesky
@@ -565,6 +579,22 @@ class TestBuildPostBluesky:
                 "My Title", "Author", "", "#python ", self.BASE_ENTRY
             )
         assert '📝 "My Title"' in builder.build_text()
+
+    def test_youtube_emoji(self):
+        handler = self._make_handler_with_fake_builder()
+        with patch.object(handler, "get_bluesky_did", return_value="did:plc:test"):
+            builder = handler.build_post_bluesky(
+                "My Video", "Author", "", "#python ", self.BASE_ENTRY, content_type="youtube"
+            )
+        assert '📺 "My Video"' in builder.build_text()
+
+    def test_podcast_emoji(self):
+        handler = self._make_handler_with_fake_builder()
+        with patch.object(handler, "get_bluesky_did", return_value="did:plc:test"):
+            builder = handler.build_post_bluesky(
+                "My Episode", "Author", "", "#python ", self.BASE_ENTRY, content_type="podcast"
+            )
+        assert '🎙️ "My Episode"' in builder.build_text()
 
     def test_post_order(self):
         # Verify: title → summary → name+handle → link → tags
@@ -647,7 +677,7 @@ class TestBuildPost:
         handler = make_handler({"platform": "mastodon", "gen_ai_support": False})
         entry = {"title": "T", "link": "https://x.com", "pub_date": "2024-01-01",
                  "tags": [], "summary": "", "media_content": []}
-        feed = {"name": "Author", "mastodon": None}
+        feed = {"name": "Author", "mastodon": None, "content_type": "blog"}
         with patch.object(handler, "build_post_mastodon", return_value="post") as m:
             handler.build_post(entry, feed)
         m.assert_called_once()
@@ -656,10 +686,31 @@ class TestBuildPost:
         handler = make_handler({"platform": "bluesky", "gen_ai_support": False})
         entry = {"title": "T", "link": "https://x.com", "pub_date": "2024-01-01",
                  "tags": [], "summary": "", "media_content": []}
-        feed = {"name": "Author", "bluesky": None}
+        feed = {"name": "Author", "bluesky": None, "content_type": "blog"}
         with patch.object(handler, "build_post_bluesky", return_value=MagicMock()) as m:
             handler.build_post(entry, feed)
         m.assert_called_once()
+
+    def test_content_type_passed_to_mastodon_builder(self):
+        handler = make_handler({"platform": "mastodon", "gen_ai_support": False})
+        entry = {"title": "T", "link": "https://x.com", "pub_date": "2024-01-01",
+                 "tags": [], "summary": "", "media_content": []}
+        feed = {"name": "Author", "mastodon": None, "content_type": "youtube"}
+        with patch.object(handler, "build_post_mastodon", return_value="post") as m:
+            handler.build_post(entry, feed)
+        _, kwargs = m.call_args
+        args = m.call_args[0]
+        assert "youtube" in args
+
+    def test_content_type_passed_to_bluesky_builder(self):
+        handler = make_handler({"platform": "bluesky", "gen_ai_support": False})
+        entry = {"title": "T", "link": "https://x.com", "pub_date": "2024-01-01",
+                 "tags": [], "summary": "", "media_content": []}
+        feed = {"name": "Author", "bluesky": None, "content_type": "podcast"}
+        with patch.object(handler, "build_post_bluesky", return_value=MagicMock()) as m:
+            handler.build_post(entry, feed)
+        args = m.call_args[0]
+        assert "podcast" in args
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# What this PR is about

- Both pyladies and rladies repos now use a single rss_feed key for all content types (blog, youtube, podcast)
- Drop the rss_feed_youtube lookup from extract_info and update tests accordingly
- Store content_type and use type-specific emoji in posts
- Extract the type field (blog/youtube/podcast) from each JSON entry and store it as content_type in the metadata. Use it when building posts to prefix the title with the matching emoji: 📝 blog, 📺 youtube, 🎙️ podcast
