### PR TITLE
fix: pass prompt as single string to google.genai generate_content

### DIFF
--- a/src/promote_blog_post.py
+++ b/src/promote_blog_post.py
@@ -421,12 +421,12 @@ class PromoteBlogPost():
         Summarize text using LLMs.
         """
         text = self.generate_text_to_summarize(entry)
-        prompt_parts = [
-            'Summarize the content of the post in maximum 60 characters.',
-            'Be as concise as possible and be engaging.',
-            'Don\'t repeat the title.',
-            text
-        ]
+        prompt = (
+            'Summarize the content of the post in maximum 60 characters. '
+            'Be as concise as possible and be engaging. '
+            "Don't repeat the title.\n\n"
+            + text
+        )
         _retryable_codes = ("429", "503")
         _max_attempts = 3
         _retry_wait = 30
@@ -435,7 +435,7 @@ class PromoteBlogPost():
             try:
                 response = self.genai_client.models.generate_content(
                     model=self.config_dict.get('gemini_model_name', ''),
-                    contents=prompt_parts
+                    contents=prompt
                 )
                 break
             except Exception as e:  # pylint: disable=broad-except


### PR DESCRIPTION
# What this PR is about

The old google.generativeai SDK treated a list of strings as parts of one user message. The new google.genai SDK treats each string as a separate conversation turn (role='user'). Consecutive same-role turns are invalid per the Gemini API, which returns 503 for every such request. Collapse the prompt list into a single string so the API receives one well-formed user turn.
