### PR TITLE
fix: retry Bluesky login 

### DIFF
--- a/src/helper/login_bluesky.py
+++ b/src/helper/login_bluesky.py
@@ -1,6 +1,7 @@
 """Module to log into Bluesky."""
 
 import logging
+import time
 from typing import TypedDict
 
 from atproto import Client
@@ -11,6 +12,9 @@ logger = logging.getLogger(__name__)
 logging.getLogger("httpx").setLevel(logging.WARNING)
 logging.getLogger("atproto").setLevel(logging.WARNING)
 logging.getLogger("atproto_client").setLevel(logging.WARNING)
+
+_MAX_LOGIN_ATTEMPTS = 3
+_RETRY_BASE_DELAY_SECONDS = 30
 
 
 class BlueskyConfig(TypedDict):
@@ -23,6 +27,9 @@ def login_bluesky(config_dict: BlueskyConfig) -> Client:
     """
     Log in to Bluesky and return the client instance.
 
+    Retries up to 3 times with linear backoff to handle transient 403s
+    caused by shared-IP rate limiting on the createSession endpoint.
+
     Args:
         config_dict: Configuration required for Bluesky login.
 
@@ -31,12 +38,27 @@ def login_bluesky(config_dict: BlueskyConfig) -> Client:
     """
     logger.info(" > Logging in as %s", config_dict["username"])
 
-    client = Client()
-    profile = client.login(
-        config_dict["username"],
-        config_dict["password"],
-    )
+    last_exception: Exception | None = None
+    for attempt in range(_MAX_LOGIN_ATTEMPTS):
+        try:
+            client = Client()
+            profile = client.login(
+                config_dict["username"],
+                config_dict["password"],
+            )
+            logger.info(" > Successfully logged in as @%s", profile.handle)
+            return client
+        except Exception as e:
+            last_exception = e
+            if attempt < _MAX_LOGIN_ATTEMPTS - 1:
+                delay = _RETRY_BASE_DELAY_SECONDS * (attempt + 1)
+                logger.warning(
+                    " > Login attempt %d/%d failed (%s), retrying in %ds",
+                    attempt + 1,
+                    _MAX_LOGIN_ATTEMPTS,
+                    e,
+                    delay,
+                )
+                time.sleep(delay)
 
-    logger.info(" > Successfully logged in as @%s", profile.handle)
-
-    return client
+    raise last_exception

--- a/tests/test_login_bluesky.py
+++ b/tests/test_login_bluesky.py
@@ -6,13 +6,14 @@ Covers:
 - Happy path: correct Client.login args, client returned
 - Regression guards: Client() constructed with no args; profile.handle read from login return value
 - Login return value: server-confirmed handle used in success log
-- Error propagation: Client() and client.login() exceptions bubble up
+- Error propagation: Client() and client.login() exceptions bubble up after all retries
+- Retry behaviour: succeeds on 2nd/3rd attempt; warning logged per failure; fresh Client per attempt
 - Edge cases: missing required config keys raise KeyError; empty-string credentials forwarded
 - Logging: login and success messages are emitted with correct content
 """
 
 import logging
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
@@ -109,10 +110,8 @@ def test_success_log_uses_server_confirmed_handle(caplog):
 
 
 def test_client_constructor_exception_propagates():
-    with patch(
-        "helper.login_bluesky.Client",
-        side_effect=ConnectionError("unreachable"),
-    ):
+    with patch("helper.login_bluesky.Client", side_effect=ConnectionError("unreachable")), \
+         patch("helper.login_bluesky.time.sleep"):
         with pytest.raises(ConnectionError, match="unreachable"):
             login_bluesky(VALID_CONFIG)
 
@@ -120,9 +119,71 @@ def test_client_constructor_exception_propagates():
 def test_login_exception_propagates():
     mock_client = MagicMock()
     mock_client.login.side_effect = PermissionError("invalid credentials")
-    with patch("helper.login_bluesky.Client", return_value=mock_client):
+    with patch("helper.login_bluesky.Client", return_value=mock_client), \
+         patch("helper.login_bluesky.time.sleep"):
         with pytest.raises(PermissionError, match="invalid credentials"):
             login_bluesky(VALID_CONFIG)
+
+
+# ---------------------------------------------------------------------------
+# Retry behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_succeeds_on_second_attempt():
+    good_client = _make_mock_client()
+    bad_client = MagicMock()
+    bad_client.login.side_effect = RuntimeError("transient 403")
+
+    with patch("helper.login_bluesky.Client", side_effect=[bad_client, good_client]), \
+         patch("helper.login_bluesky.time.sleep") as mock_sleep:
+        result = login_bluesky(VALID_CONFIG)
+
+    assert result is good_client
+    mock_sleep.assert_called_once_with(30)
+
+
+def test_succeeds_on_third_attempt():
+    good_client = _make_mock_client()
+    bad_client_1 = MagicMock()
+    bad_client_1.login.side_effect = RuntimeError("transient 403")
+    bad_client_2 = MagicMock()
+    bad_client_2.login.side_effect = RuntimeError("transient 403")
+
+    with patch("helper.login_bluesky.Client", side_effect=[bad_client_1, bad_client_2, good_client]), \
+         patch("helper.login_bluesky.time.sleep") as mock_sleep:
+        result = login_bluesky(VALID_CONFIG)
+
+    assert result is good_client
+    mock_sleep.assert_has_calls([call(30), call(60)])
+
+
+def test_fresh_client_created_on_each_attempt():
+    # Each retry must use a new Client() — not reuse a client that failed auth.
+    bad = MagicMock()
+    bad.login.side_effect = RuntimeError("fail")
+
+    with patch("helper.login_bluesky.Client", side_effect=[bad, bad, bad]) as mock_cls, \
+         patch("helper.login_bluesky.time.sleep"):
+        with pytest.raises(RuntimeError):
+            login_bluesky(VALID_CONFIG)
+
+    assert mock_cls.call_count == 3
+
+
+def test_warning_logged_per_failed_attempt(caplog):
+    bad_client = MagicMock()
+    bad_client.login.side_effect = RuntimeError("transient")
+    good_client = _make_mock_client()
+
+    with patch("helper.login_bluesky.Client", side_effect=[bad_client, good_client]), \
+         patch("helper.login_bluesky.time.sleep"), \
+         caplog.at_level(logging.WARNING, logger="helper.login_bluesky"):
+        login_bluesky(VALID_CONFIG)
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    assert "1/3" in warnings[0].message
 
 
 # ---------------------------------------------------------------------------
@@ -132,14 +193,16 @@ def test_login_exception_propagates():
 
 def test_missing_username_raises_key_error():
     bad_config = {"password": "hunter2"}
-    with patch("helper.login_bluesky.Client"):
+    with patch("helper.login_bluesky.Client"), \
+         patch("helper.login_bluesky.time.sleep"):
         with pytest.raises(KeyError):
             login_bluesky(bad_config)  # type: ignore[arg-type]
 
 
 def test_missing_password_raises_key_error():
     bad_config = {"username": "test_bot.bsky.social"}
-    with patch("helper.login_bluesky.Client"):
+    with patch("helper.login_bluesky.Client"), \
+         patch("helper.login_bluesky.time.sleep"):
         with pytest.raises(KeyError):
             login_bluesky(bad_config)  # type: ignore[arg-type]
 
@@ -191,7 +254,8 @@ def test_exactly_two_log_messages_emitted(caplog):
 def test_no_success_log_when_login_raises(caplog):
     mock_client = MagicMock()
     mock_client.login.side_effect = RuntimeError("boom")
-    with patch("helper.login_bluesky.Client", return_value=mock_client):
+    with patch("helper.login_bluesky.Client", return_value=mock_client), \
+         patch("helper.login_bluesky.time.sleep"):
         with caplog.at_level(logging.INFO, logger="helper.login_bluesky"):
             with pytest.raises(RuntimeError):
                 login_bluesky(VALID_CONFIG)


### PR DESCRIPTION
# What this PR is about

Bluesky's createSession endpoint returns 403 Forbidden when shared cloud IPs (including GitHub Actions runners) hit its rate limit. Add up to 3 attempts with 30s linear backoff so transient blocks don't fail workflows.
