### PR TITLE
Fix dependency conflict: cryptography 48 incompatible with atproto

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ anyio==4.13.0
 appnope==0.1.4; platform_system == "Darwin"
 astroid==4.0.4
 asttokens==3.0.1
-atproto==0.0.65
+atproto==0.0.69
 babel==2.18.0
 backrefs==6.2
 beautifulsoup4==4.14.3
@@ -18,7 +18,7 @@ charset-normalizer==3.4.7
 click==8.3.3
 colorama==0.4.6
 comm==0.2.3
-cryptography==48.0.1
+cryptography==46.0.7
 debugpy==1.8.20
 decorator==5.2.1
 dill==0.4.1; python_version >= "3.11"


### PR DESCRIPTION
## Summary

- The Dependabot security bump of `cryptography` from 46.0.7 → 48.0.1 (PR #173) broke all pipelines using `atproto`
- `atproto` (all versions up to and including 0.0.69) requires `cryptography<47`, causing a `ResolutionImpossible` error during `pip install`
- Fix: upgrade `atproto` to 0.0.69 (latest) and pin `cryptography` back to 46.0.7 — the highest version satisfying atproto's constraint

## Root cause

```
ERROR: Cannot install -r requirements.txt (line 9) and cryptography==48.0.1
because these package versions have conflicting dependencies.
  atproto 0.0.65 depends on cryptography<47 and >=41.0.7
```

## Follow-up

Once atproto releases a version that supports `cryptography>=47`, we can re-upgrade cryptography for the full security fix.